### PR TITLE
[FM05] Feed Phase 1 - SELECT query builder + filtres permissifs + pagination (issue #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,75 @@ La progression est déduite des champs déjà remplis dans `user_profiles` (pas 
 | E2E (Playwright) | `e2e/onboarding.spec.ts` | Auth guards, XSS, redirect chains, no 500 |
 | pgTAP (SQL) | `supabase/tests/rls_user_profiles.sql` | Isolation utilisateur + onboarding upsert pattern (7 assertions) |
 
+## Feed (FM05)
+
+Le feed est la page centrale du produit. Il liste les offres actives triées par `posted_at DESC` (Phase 1 — sans scoring IA).
+
+### Architecture
+
+```
+app/(protected)/feed/page.tsx          Server Component — fetch + guards
+  src/lib/feed/queries.ts              Query builder SQL direct (pas de RPC)
+  src/lib/feed/schemas.ts              Zod validation des query params
+  components/feed/JobFeedList.tsx      Liste JobCard + pagination Previous/Next
+  components/feed/FeedFilters.tsx      Panneau filtres (sidebar desktop / Sheet mobile)
+  components/feed/FeedSkeleton.tsx     Skeleton de chargement (existant)
+  components/jobs/JobCard.tsx          Carte offre (variante 'feed')
+```
+
+### Requête Phase 1
+
+```sql
+SELECT id, title, company, logo_url, source_url, source,
+       skills_required, salary_min, salary_max, salary_currency, salary_period,
+       contract_type, geo_policy, seniority, red_flags, posted_at, ingested_at
+FROM jobs
+WHERE status = 'active'
+ORDER BY posted_at DESC, ingested_at DESC
+LIMIT 20 OFFSET :offset
+```
+
+### Filtres permissifs (NULL-tolerant)
+
+Les colonnes IA (`contract_type`, `seniority`, `geo_policy`, `salary_min`) peuvent être NULL. Un job NULL passe tous les filtres :
+
+```sql
+WHERE (contract_type = 'contractor' OR contract_type IS NULL)
+```
+
+Filtres disponibles : contract type · seniority · location policy · minimum salary (preset).
+
+### Guards
+
+| Condition | Comportement |
+|---|---|
+| Non authentifié | Redirect → `/auth/login` |
+| `onboarding_completed_at IS NULL` | Redirect → `/onboarding` |
+| DB vide | EmptyState "check back once cron has run" |
+| Filtres sans résultat | EmptyState "no jobs match filters" |
+| Erreur DB | Inline error + lien Refresh |
+
+### Pagination
+
+20 offres par page via `?page=N`. Les filtres sont persistés dans l'URL — le rechargement ou le partage de lien conserve les filtres.
+
+### Fichiers clés
+
+| Fichier | Rôle |
+|---|---|
+| `src/lib/feed/queries.ts` | `fetchFeedJobs(supabase, filters, page)` — retourne `{ jobs, total }` |
+| `src/lib/feed/schemas.ts` | `parseFeedFilters(rawParams)` — validation Zod, `.catch(undefined)` sur chaque champ |
+| `components/feed/job-feed-list.tsx` | Rendu liste + contrôles pagination (Server Component) |
+| `components/feed/feed-filters.tsx` | Filtres radio + select (Client Component, auto-submit onChange) |
+
+### Tests
+
+| Type | Fichier | Couverture |
+|---|---|---|
+| Unit (Vitest) | `src/lib/feed/__tests__/schemas.test.ts` | parseFeedFilters — valeurs valides, coercions, XSS, defaults |
+| Unit (Vitest) | `src/lib/feed/__tests__/queries.test.ts` | fetchFeedJobs — colonnes, filtres NULL, pagination, erreurs |
+| Unit (Vitest) | `components/feed/__tests__/feed-components.test.tsx` | JobFeedList (empty states, pagination) + FeedFilters (options, badges) |
+
 ## Navigation mobile
 
 Le `Header` affiche une navigation desktop (liens horizontaux) visible à partir du breakpoint `md` (768 px). En dessous, un drawer slide-in (bouton burger) prend le relais.

--- a/app/(protected)/feed/page.tsx
+++ b/app/(protected)/feed/page.tsx
@@ -1,10 +1,15 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
-import { Bookmark } from 'lucide-react'
 import { getUserWithProfile } from '@/src/lib/auth/get-user'
+import { parseFeedFilters } from '@/src/lib/feed/schemas'
+import { fetchFeedJobs } from '@/src/lib/feed/queries'
 import { Header } from '@/components/layout/header'
 import { Footer } from '@/components/layout/footer'
-import { EmptyState } from '@/components/states/empty-state'
+import { FeedFilters } from '@/components/feed/feed-filters'
+import { JobFeedList } from '@/components/feed/job-feed-list'
+import { Button } from '@/components/ui/button'
+import { AlertCircle } from 'lucide-react'
 
 export const metadata: Metadata = {
   title: 'Your feed — JobNomad',
@@ -12,43 +17,104 @@ export const metadata: Metadata = {
 }
 
 /**
- * /feed — Authenticated feed page.
+ * /feed — Authenticated feed page (Phase 1: plain SELECT, no scoring).
  *
  * Guards:
- *  - Not authenticated → /auth/login (layout handles this, we add belt+braces)
- *  - Onboarding incomplete → /onboarding
+ *  - Not authenticated  → /auth/login  (layout handles this; belt+braces here)
+ *  - Onboarding pending → /onboarding
  *
- * Full feed implementation in issue #9 (F-M05/F-M06).
+ * searchParams are async per Next.js 16 convention (see AGENTS.md).
+ *
+ * Architecture: this Server Component is the only place that fetches data.
+ * FeedFilters + JobFeedList are pure presentational — they receive data as
+ * props. No client-side fetching in Phase 1.
  */
-export default async function FeedPage() {
-  const { user, profile } = await getUserWithProfile()
+export default async function FeedPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
+  // -- Auth + onboarding guards --------------------------------------------
+  const { user, profile, supabase: userSupabase } = await getUserWithProfile()
 
   if (!user) redirect('/auth/login')
-
-  // Onboarding guard — must complete wizard before accessing feed
   if (!profile?.onboarding_completed_at) redirect('/onboarding')
 
+  // -- Parse + validate filters from URL query params ----------------------
+  const rawParams = await searchParams
+  const filters = parseFeedFilters(rawParams)
+
+  // -- Fetch jobs ----------------------------------------------------------
+  // We use the user-context client (row-level security active) so the
+  // `jobs_select_active` policy applies automatically.
+  let feedResult: Awaited<ReturnType<typeof fetchFeedJobs>> | null = null
+  let fetchError: string | null = null
+
+  try {
+    feedResult = await fetchFeedJobs(userSupabase, filters, filters.page)
+  } catch (err) {
+    console.error('[feed] fetch failed', err)
+    fetchError = err instanceof Error ? err.message : 'Unknown error'
+  }
+
+  // -- Render --------------------------------------------------------------
   return (
     <div className="flex flex-col flex-1 bg-bg text-text">
       <Header variant="app" userEmail={user.email} />
 
-      <main id="main" className="flex flex-col flex-1 px-6 py-12">
-        <div className="mx-auto w-full max-w-4xl">
-          <div className="mb-8">
+      <main id="main" className="flex flex-col flex-1 px-4 sm:px-6 py-8">
+        <div className="mx-auto w-full max-w-5xl">
+          {/* -- Page header ----------------------------------------------- */}
+          <div className="mb-6">
             <h1 className="text-display-lg text-text">Your feed</h1>
-            <p className="text-body-lg text-text-soft mt-1">
-              Signed in as{' '}
-              <span className="text-mono-sm text-primary">{user.email}</span>
+            <p className="text-body-md text-text-soft mt-1">
+              Remote jobs sorted by date — newest first
             </p>
           </div>
 
-          {/* Feed placeholder — replace with real DB query in issue #9 (F-M05) */}
-          <EmptyState
-            icon={Bookmark}
-            heading="Jobs are loading"
-            description="Your personalized feed is almost ready. Come back in a minute or refresh."
-            action={{ label: 'Refresh feed', href: '/feed' }}
-          />
+          {/* -- Mobile filters trigger + content row ---------------------- */}
+          <div className="flex flex-col gap-4">
+            {/* Mobile: filters button above the list */}
+            <div className="md:hidden">
+              <FeedFilters filters={filters} />
+            </div>
+
+            {/* Desktop: sidebar + list side-by-side */}
+            <div className="flex gap-8 items-start">
+              {/* Desktop sidebar */}
+              <FeedFilters filters={filters} />
+
+              {/* Main content */}
+              <div className="flex-1 min-w-0">
+                {fetchError ? (
+                  <div
+                    role="alert"
+                    className="flex flex-col items-center justify-center text-center gap-4 py-16 px-6"
+                  >
+                    <div className="flex items-center justify-center w-14 h-14 rounded-full bg-danger-soft">
+                      <AlertCircle className="h-6 w-6 text-danger" aria-hidden />
+                    </div>
+                    <div className="flex flex-col gap-1.5 max-w-xs">
+                      <h3 className="text-display-sm text-text">Failed to load jobs</h3>
+                      <p className="text-body-md text-text-soft">
+                        Something went wrong fetching your feed. Please try refreshing.
+                      </p>
+                    </div>
+                    <Button variant="outline" asChild>
+                      <Link href="/feed">Refresh</Link>
+                    </Button>
+                  </div>
+                ) : (
+                  <JobFeedList
+                    jobs={feedResult?.jobs ?? []}
+                    total={feedResult?.total ?? 0}
+                    page={filters.page}
+                    filters={filters}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
         </div>
       </main>
 

--- a/components/feed/__tests__/feed-components.test.tsx
+++ b/components/feed/__tests__/feed-components.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * Tests for feed components:
+ *   - JobFeedList (empty state, job cards, pagination)
+ *   - FeedFilters (active count, render without crash)
+ *
+ * Uses Vitest + React Testing Library + happy-dom.
+ * No jest-dom — use .not.toBeNull() / .not.toBeUndefined() etc.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { JobFeedList } from '../job-feed-list'
+import { FeedFilters } from '../feed-filters'
+import type { FeedJob } from '@/src/lib/feed/queries'
+import type { FeedFilters as FeedFiltersType } from '@/src/lib/feed/schemas'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const defaultFilters: FeedFiltersType = {
+  page: 1,
+  contract: undefined,
+  seniority: undefined,
+  geo_policy: undefined,
+  salary_min: undefined,
+}
+
+const makeJob = (overrides?: Partial<FeedJob>): FeedJob => ({
+  id: 'job-1',
+  title: 'Senior Engineer',
+  company: 'Acme Corp',
+  logo_url: null,
+  source_url: 'https://example.com/apply',
+  source: 'remoteok',
+  skills_required: ['TypeScript', 'React'],
+  salary_min: 80000,
+  salary_max: 120000,
+  salary_currency: 'USD',
+  salary_period: 'year',
+  contract_type: 'contractor',
+  geo_policy: 'worldwide',
+  seniority: 'senior',
+  red_flags: [],
+  posted_at: new Date(Date.now() - 86_400_000).toISOString(), // yesterday
+  ingested_at: new Date().toISOString(),
+  ...overrides,
+})
+
+// ---------------------------------------------------------------------------
+// JobFeedList
+// ---------------------------------------------------------------------------
+
+describe('JobFeedList', () => {
+  it('renders "No jobs found" empty state when jobs array is empty', () => {
+    render(
+      <JobFeedList jobs={[]} total={0} page={1} filters={defaultFilters} />,
+    )
+    expect(screen.getByText('No jobs found')).not.toBeNull()
+  })
+
+  it('shows correct empty message when total=0 (DB empty)', () => {
+    render(
+      <JobFeedList jobs={[]} total={0} page={1} filters={defaultFilters} />,
+    )
+    // Partial match
+    const el = screen.getAllByText(/check back once the ingestion cron/i)
+    expect(el.length).toBeGreaterThan(0)
+  })
+
+  it('shows "no match" message when total>0 but page returns 0 jobs', () => {
+    render(
+      <JobFeedList jobs={[]} total={50} page={3} filters={defaultFilters} />,
+    )
+    const el = screen.getAllByText(/no jobs match your current filters/i)
+    expect(el.length).toBeGreaterThan(0)
+  })
+
+  it('renders job card for each job', () => {
+    const jobs = [makeJob({ id: 'a', title: 'Job A' }), makeJob({ id: 'b', title: 'Job B' })]
+    render(
+      <JobFeedList jobs={jobs} total={2} page={1} filters={defaultFilters} />,
+    )
+    expect(screen.getByText('Job A')).not.toBeNull()
+    expect(screen.getByText('Job B')).not.toBeNull()
+  })
+
+  it('renders pagination info text', () => {
+    const jobs = [makeJob()]
+    render(
+      <JobFeedList jobs={jobs} total={1} page={1} filters={defaultFilters} />,
+    )
+    const paginationEl = screen.getAllByText(/page 1 of 1/i)
+    expect(paginationEl.length).toBeGreaterThan(0)
+  })
+
+  it('disables Previous button on first page (aria-disabled)', () => {
+    render(
+      <JobFeedList jobs={[makeJob()]} total={1} page={1} filters={defaultFilters} />,
+    )
+    // The disabled Previous is a <button aria-disabled="true">
+    const prevBtns = screen.getAllByRole('button')
+    const prevBtn = prevBtns.find((b) => b.textContent?.includes('Previous'))
+    expect(prevBtn).not.toBeUndefined()
+    expect(
+      prevBtn!.getAttribute('disabled') !== null ||
+      prevBtn!.getAttribute('aria-disabled') === 'true'
+    ).toBe(true)
+  })
+
+  it('shows Previous link on page 2', () => {
+    const jobs = Array.from({ length: 20 }, (_, i) => makeJob({ id: String(i) }))
+    render(
+      <JobFeedList jobs={jobs} total={40} page={2} filters={defaultFilters} />,
+    )
+    // Page 2 — Previous should be a link
+    const prevLink = screen.queryByRole('link', { name: /previous page/i })
+    expect(prevLink).not.toBeNull()
+  })
+
+  it('disables Next button on last page (aria-disabled)', () => {
+    render(
+      <JobFeedList jobs={[makeJob()]} total={1} page={1} filters={defaultFilters} />,
+    )
+    const allBtns = screen.getAllByRole('button')
+    const nextBtn = allBtns.find((b) => b.textContent?.includes('Next'))
+    expect(nextBtn).not.toBeUndefined()
+    expect(
+      nextBtn!.getAttribute('disabled') !== null ||
+      nextBtn!.getAttribute('aria-disabled') === 'true'
+    ).toBe(true)
+  })
+
+  it('shows Next link when more pages exist', () => {
+    const jobs = Array.from({ length: 20 }, (_, i) => makeJob({ id: String(i) }))
+    render(
+      <JobFeedList jobs={jobs} total={40} page={1} filters={defaultFilters} />,
+    )
+    const nextLink = screen.queryByRole('link', { name: /next page/i })
+    expect(nextLink).not.toBeNull()
+  })
+
+  it('handles red_flags that are strings (permissive parsing)', () => {
+    const job = makeJob({ red_flags: ['No overtime pay', 'Vague role'] })
+    expect(() =>
+      render(
+        <JobFeedList jobs={[job]} total={1} page={1} filters={defaultFilters} />,
+      ),
+    ).not.toThrow()
+  })
+
+  it('handles null red_flags gracefully', () => {
+    const job = makeJob({ red_flags: null as unknown as [] })
+    expect(() =>
+      render(
+        <JobFeedList jobs={[job]} total={1} page={1} filters={defaultFilters} />,
+      ),
+    ).not.toThrow()
+  })
+
+  it('renders salary when both min and max present', () => {
+    const job = makeJob({ salary_min: 80000, salary_max: 120000, salary_currency: 'USD', salary_period: 'year' })
+    const { container } = render(
+      <JobFeedList jobs={[job]} total={1} page={1} filters={defaultFilters} />,
+    )
+    // Salary element should contain numbers — use container text check
+    expect(container.textContent).toContain('80')
+    expect(container.textContent).toContain('120')
+  })
+
+  it('renders without crash when salary_min and salary_max are null', () => {
+    const job = makeJob({ salary_min: null, salary_max: null })
+    expect(() =>
+      render(
+        <JobFeedList jobs={[job]} total={1} page={1} filters={defaultFilters} />,
+      ),
+    ).not.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FeedFilters
+// ---------------------------------------------------------------------------
+
+describe('FeedFilters', () => {
+  it('renders without crashing with empty filters', () => {
+    expect(() =>
+      render(<FeedFilters filters={defaultFilters} />),
+    ).not.toThrow()
+  })
+
+  it('renders "Filters" label', () => {
+    render(<FeedFilters filters={defaultFilters} />)
+    // Appears in desktop sidebar AND mobile Sheet title — both valid
+    const headings = screen.getAllByText('Filters')
+    expect(headings.length).toBeGreaterThan(0)
+  })
+
+  it('renders "Reset all filters" button (at least one)', () => {
+    render(<FeedFilters filters={defaultFilters} />)
+    // Desktop sidebar has it; mobile Sheet is initially closed (portal not rendered)
+    const resetBtns = screen.getAllByText(/reset all filters/i)
+    expect(resetBtns.length).toBeGreaterThan(0)
+  })
+
+  it('renders contract type options', () => {
+    render(<FeedFilters filters={defaultFilters} />)
+    const contractorLabels = screen.getAllByText(/contractor \/ freelance/i)
+    expect(contractorLabels.length).toBeGreaterThan(0)
+  })
+
+  it('renders seniority options', () => {
+    render(<FeedFilters filters={defaultFilters} />)
+    const juniorLabels = screen.getAllByText('Junior')
+    expect(juniorLabels.length).toBeGreaterThan(0)
+    const seniorLabels = screen.getAllByText('Senior')
+    expect(seniorLabels.length).toBeGreaterThan(0)
+  })
+
+  it('renders minimum salary dropdown', () => {
+    render(<FeedFilters filters={defaultFilters} />)
+    // There may be multiple selects (sidebar + hidden mobile form)
+    const selects = screen.getAllByRole('combobox')
+    expect(selects.length).toBeGreaterThan(0)
+  })
+
+  it('shows active filter badge when contract is set', () => {
+    render(
+      <FeedFilters filters={{ ...defaultFilters, contract: 'contractor' }} />,
+    )
+    const badges = screen.getAllByText('1')
+    expect(badges.length).toBeGreaterThan(0)
+  })
+
+  it('shows correct active count for multiple filters', () => {
+    render(
+      <FeedFilters
+        filters={{ ...defaultFilters, contract: 'contractor', seniority: 'senior', salary_min: 80000 }}
+      />,
+    )
+    const badges = screen.getAllByText('3')
+    expect(badges.length).toBeGreaterThan(0)
+  })
+
+  it('shows "Clear" button when contract filter is active', () => {
+    render(
+      <FeedFilters filters={{ ...defaultFilters, contract: 'contractor' }} />,
+    )
+    const clearBtns = screen.getAllByText('Clear')
+    expect(clearBtns.length).toBeGreaterThan(0)
+  })
+})

--- a/components/feed/feed-filters.tsx
+++ b/components/feed/feed-filters.tsx
@@ -1,0 +1,305 @@
+/**
+ * FeedFilters — filter panel for the job feed.
+ *
+ * Layout:
+ *   Desktop: sticky left sidebar (shown via CSS at md+)
+ *   Mobile:  Sheet (drawer) triggered by a "Filters" button
+ *
+ * Filters are submitted as URL query params via a plain <form> with
+ * method="get" action="/feed" — no JS required for basic usage. This
+ * keeps the feed fully server-rendered and sharable via URL.
+ *
+ * Active filter count badge shows on mobile trigger for discoverability.
+ */
+
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useRef } from 'react'
+import { SlidersHorizontal, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet'
+import { Label } from '@/components/ui/label'
+import type { FeedFilters } from '@/src/lib/feed/schemas'
+
+// ---------------------------------------------------------------------------
+// Filter options
+// ---------------------------------------------------------------------------
+
+const CONTRACT_OPTIONS = [
+  { value: 'contractor', label: 'Contractor / Freelance' },
+  { value: 'employee', label: 'Employee (Full-time)' },
+  { value: 'both', label: 'Either' },
+]
+
+const SENIORITY_OPTIONS = [
+  { value: 'junior', label: 'Junior' },
+  { value: 'mid', label: 'Mid-level' },
+  { value: 'senior', label: 'Senior' },
+  { value: 'lead', label: 'Lead / Principal' },
+  { value: 'any', label: 'Any level' },
+]
+
+const GEO_OPTIONS = [
+  { value: 'worldwide', label: 'Worldwide' },
+  { value: 'specific_regions', label: 'Specific regions' },
+  { value: 'specific_countries', label: 'Specific countries' },
+]
+
+const SALARY_PRESETS = [
+  { value: 40000, label: '$40k+' },
+  { value: 60000, label: '$60k+' },
+  { value: 80000, label: '$80k+' },
+  { value: 100000, label: '$100k+' },
+  { value: 120000, label: '$120k+' },
+]
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function countActiveFilters(filters: FeedFilters): number {
+  let n = 0
+  if (filters.contract) n++
+  if (filters.seniority) n++
+  if (filters.geo_policy) n++
+  if (filters.salary_min != null) n++
+  return n
+}
+
+// ---------------------------------------------------------------------------
+// Inner form (shared between sidebar + sheet)
+// ---------------------------------------------------------------------------
+
+interface FilterFormProps {
+  filters: FeedFilters
+}
+
+function FilterForm({ filters }: FilterFormProps) {
+  const router = useRouter()
+  const formRef = useRef<HTMLFormElement>(null)
+
+  function handleChange() {
+    // Auto-submit on any filter change so the URL updates immediately.
+    // The form's native serialisation handles everything — we just need to
+    // reset to page 1 on filter change.
+    if (!formRef.current) return
+    const data = new FormData(formRef.current)
+    const params = new URLSearchParams()
+    for (const [k, v] of data.entries()) {
+      if (typeof v === 'string' && v) params.set(k, v)
+    }
+    // Always reset to page 1 when filters change
+    params.delete('page')
+    router.push(`/feed?${params.toString()}`)
+  }
+
+  function handleReset() {
+    router.push('/feed')
+  }
+
+  return (
+    <form
+      ref={formRef}
+      method="get"
+      action="/feed"
+      className="flex flex-col gap-6"
+      aria-label="Job filters"
+    >
+      {/* -- Contract type -------------------------------------------------- */}
+      <fieldset className="flex flex-col gap-2 border-none p-0 m-0">
+        <legend className="text-label-sm text-text font-medium mb-1">Contract type</legend>
+        {CONTRACT_OPTIONS.map((opt) => (
+          <label key={opt.value} className="flex items-center gap-2 cursor-pointer text-body-sm text-text-soft">
+            <input
+              type="radio"
+              name="contract"
+              value={opt.value}
+              defaultChecked={filters.contract === opt.value}
+              onChange={handleChange}
+              className="accent-primary"
+            />
+            {opt.label}
+          </label>
+        ))}
+        {filters.contract && (
+          <button
+            type="button"
+            onClick={() => {
+              if (formRef.current) {
+                const radios = formRef.current.querySelectorAll<HTMLInputElement>('input[name="contract"]')
+                radios.forEach(r => { r.checked = false })
+              }
+              handleChange()
+            }}
+            className="text-label-xs text-text-muted hover:text-text-soft transition-colors text-left mt-0.5"
+          >
+            Clear
+          </button>
+        )}
+      </fieldset>
+
+      {/* -- Seniority ------------------------------------------------------- */}
+      <fieldset className="flex flex-col gap-2 border-none p-0 m-0">
+        <legend className="text-label-sm text-text font-medium mb-1">Seniority</legend>
+        {SENIORITY_OPTIONS.map((opt) => (
+          <label key={opt.value} className="flex items-center gap-2 cursor-pointer text-body-sm text-text-soft">
+            <input
+              type="radio"
+              name="seniority"
+              value={opt.value}
+              defaultChecked={filters.seniority === opt.value}
+              onChange={handleChange}
+              className="accent-primary"
+            />
+            {opt.label}
+          </label>
+        ))}
+        {filters.seniority && (
+          <button
+            type="button"
+            onClick={() => {
+              if (formRef.current) {
+                const radios = formRef.current.querySelectorAll<HTMLInputElement>('input[name="seniority"]')
+                radios.forEach(r => { r.checked = false })
+              }
+              handleChange()
+            }}
+            className="text-label-xs text-text-muted hover:text-text-soft transition-colors text-left mt-0.5"
+          >
+            Clear
+          </button>
+        )}
+      </fieldset>
+
+      {/* -- Geo policy ------------------------------------------------------ */}
+      <fieldset className="flex flex-col gap-2 border-none p-0 m-0">
+        <legend className="text-label-sm text-text font-medium mb-1">Location policy</legend>
+        {GEO_OPTIONS.map((opt) => (
+          <label key={opt.value} className="flex items-center gap-2 cursor-pointer text-body-sm text-text-soft">
+            <input
+              type="radio"
+              name="geo_policy"
+              value={opt.value}
+              defaultChecked={filters.geo_policy === opt.value}
+              onChange={handleChange}
+              className="accent-primary"
+            />
+            {opt.label}
+          </label>
+        ))}
+        {filters.geo_policy && (
+          <button
+            type="button"
+            onClick={() => {
+              if (formRef.current) {
+                const radios = formRef.current.querySelectorAll<HTMLInputElement>('input[name="geo_policy"]')
+                radios.forEach(r => { r.checked = false })
+              }
+              handleChange()
+            }}
+            className="text-label-xs text-text-muted hover:text-text-soft transition-colors text-left mt-0.5"
+          >
+            Clear
+          </button>
+        )}
+      </fieldset>
+
+      {/* -- Minimum salary -------------------------------------------------- */}
+      <fieldset className="flex flex-col gap-2 border-none p-0 m-0">
+        <legend className="text-label-sm text-text font-medium mb-1">
+          Minimum salary (USD / year)
+        </legend>
+        <Label htmlFor="salary_min" className="sr-only">Minimum salary preset</Label>
+        <select
+          id="salary_min"
+          name="salary_min"
+          defaultValue={filters.salary_min != null ? String(filters.salary_min) : ''}
+          onChange={handleChange}
+          className="w-full rounded-md border border-border bg-surface text-body-sm text-text px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+        >
+          <option value="">No minimum</option>
+          {SALARY_PRESETS.map((p) => (
+            <option key={p.value} value={String(p.value)}>
+              {p.label}
+            </option>
+          ))}
+        </select>
+      </fieldset>
+
+      {/* -- Reset all ------------------------------------------------------- */}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={handleReset}
+        className="w-full text-text-muted"
+      >
+        <X className="h-3.5 w-3.5 mr-1.5" aria-hidden />
+        Reset all filters
+      </Button>
+    </form>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+interface FeedFiltersProps {
+  filters: FeedFilters
+}
+
+export function FeedFilters({ filters }: FeedFiltersProps) {
+  const activeCount = countActiveFilters(filters)
+
+  return (
+    <>
+      {/* -- Desktop sidebar (md+) ----------------------------------------- */}
+      <aside
+        className="hidden md:flex flex-col gap-2 w-56 shrink-0 sticky top-6 self-start"
+        aria-label="Filter jobs"
+      >
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-label-md text-text font-medium">Filters</span>
+          {activeCount > 0 && (
+            <Badge variant="secondary" size="sm">
+              {activeCount}
+            </Badge>
+          )}
+        </div>
+        <FilterForm filters={filters} />
+      </aside>
+
+      {/* -- Mobile trigger (< md) ----------------------------------------- */}
+      <div className="md:hidden">
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant="outline" size="sm" className="gap-2">
+              <SlidersHorizontal className="h-4 w-4" aria-hidden />
+              Filters
+              {activeCount > 0 && (
+                <Badge variant="secondary" size="sm" className="ml-1">
+                  {activeCount}
+                </Badge>
+              )}
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left" className="w-72 overflow-y-auto">
+            <SheetHeader className="mb-6">
+              <SheetTitle>Filter jobs</SheetTitle>
+            </SheetHeader>
+            <FilterForm filters={filters} />
+          </SheetContent>
+        </Sheet>
+      </div>
+    </>
+  )
+}

--- a/components/feed/job-feed-list.tsx
+++ b/components/feed/job-feed-list.tsx
@@ -1,0 +1,188 @@
+/**
+ * JobFeedList — renders the list of job cards + Previous/Next pagination.
+ *
+ * This is a Server Component: pagination is done via URL query params (?page=N)
+ * so the whole page re-fetches from the server (no client state needed for
+ * Phase 1). This also means the browser Back button works correctly.
+ *
+ * Props:
+ *   jobs    — pre-fetched array of FeedJob (from queries.ts)
+ *   total   — total count from DB (for pagination math)
+ *   page    — current 1-indexed page
+ *   filters — current filters (serialised back to href for pagination links)
+ */
+
+import Link from 'next/link'
+import { Briefcase, ChevronLeft, ChevronRight } from 'lucide-react'
+import { JobCard } from '@/components/jobs/job-card'
+import { EmptyState } from '@/components/states/empty-state'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { FeedJob } from '@/src/lib/feed/queries'
+import type { FeedFilters } from '@/src/lib/feed/schemas'
+import { FEED_PAGE_SIZE } from '@/src/lib/feed/queries'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Format a FeedJob into the JobCardData shape expected by JobCard. */
+function toJobCardData(job: FeedJob) {
+  // Build salary string
+  let salary: string | undefined
+  if (job.salary_min != null || job.salary_max != null) {
+    const currency = job.salary_currency ?? 'USD'
+    const period = job.salary_period ?? 'year'
+    const fmt = (n: number) =>
+      new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency,
+        maximumFractionDigits: 0,
+      }).format(n)
+    if (job.salary_min != null && job.salary_max != null) {
+      salary = `${fmt(job.salary_min)} – ${fmt(job.salary_max)} / ${period}`
+    } else if (job.salary_min != null) {
+      salary = `From ${fmt(job.salary_min)} / ${period}`
+    } else if (job.salary_max != null) {
+      salary = `Up to ${fmt(job.salary_max!)} / ${period}`
+    }
+  }
+
+  // Parse red_flags — permissive: ignore if not array
+  let redFlags: { reason: string }[] = []
+  if (Array.isArray(job.red_flags)) {
+    redFlags = (job.red_flags as unknown[])
+      .filter((f): f is string => typeof f === 'string')
+      .map((reason) => ({ reason }))
+  }
+
+  // Format posted_at relative to today
+  let posted: string | undefined
+  if (job.posted_at) {
+    const diffMs = Date.now() - new Date(job.posted_at).getTime()
+    const diffDays = Math.floor(diffMs / 86_400_000)
+    if (diffDays === 0) posted = 'Today'
+    else if (diffDays === 1) posted = 'Yesterday'
+    else if (diffDays < 14) posted = `${diffDays}d ago`
+    else if (diffDays < 60) posted = `${Math.floor(diffDays / 7)}w ago`
+    else posted = `${Math.floor(diffDays / 30)}mo ago`
+  }
+
+  return {
+    id: job.id,
+    title: job.title,
+    company: job.company,
+    applyUrl: job.source_url,
+    salary,
+    posted,
+    type: job.contract_type as 'contractor' | 'full-time' | undefined,
+    tags: job.skills_required.slice(0, 6), // cap displayed tags
+    redFlags: redFlags.length > 0 ? redFlags : undefined,
+  }
+}
+
+/** Build an href that preserves existing filters, updating only ?page=. */
+function buildPageHref(
+  filters: FeedFilters,
+  targetPage: number,
+): string {
+  const params = new URLSearchParams()
+  if (filters.contract) params.set('contract', filters.contract)
+  if (filters.seniority) params.set('seniority', filters.seniority)
+  if (filters.geo_policy) params.set('geo_policy', filters.geo_policy)
+  if (filters.salary_min != null) params.set('salary_min', String(filters.salary_min))
+  params.set('page', String(targetPage))
+  return `/feed?${params.toString()}`
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface JobFeedListProps {
+  jobs: FeedJob[]
+  total: number
+  page: number
+  filters: FeedFilters
+  className?: string
+}
+
+export function JobFeedList({
+  jobs,
+  total,
+  page,
+  filters,
+  className,
+}: JobFeedListProps) {
+  const totalPages = Math.max(1, Math.ceil(total / FEED_PAGE_SIZE))
+  const hasPrev = page > 1
+  const hasNext = page < totalPages
+
+  if (jobs.length === 0) {
+    return (
+      <EmptyState
+        icon={Briefcase}
+        heading="No jobs found"
+        description={
+          total === 0
+            ? 'The job feed is empty — check back once the ingestion cron has run.'
+            : 'No jobs match your current filters. Try widening your search.'
+        }
+      />
+    )
+  }
+
+  return (
+    <section aria-label="Job listings" className={cn('flex flex-col gap-4', className)}>
+      {/* -- Job cards ------------------------------------------------------- */}
+      <ol className="flex flex-col gap-3 list-none p-0 m-0">
+        {jobs.map((job) => (
+          <li key={job.id}>
+            <JobCard job={toJobCardData(job)} variant="feed" />
+          </li>
+        ))}
+      </ol>
+
+      {/* -- Pagination controls --------------------------------------------- */}
+      <nav
+        aria-label="Pagination"
+        className="flex items-center justify-between pt-2"
+      >
+        <span className="text-body-sm text-text-muted">
+          {total.toLocaleString()} job{total !== 1 ? 's' : ''} · page {page} of{' '}
+          {totalPages}
+        </span>
+
+        <div className="flex gap-2">
+          {hasPrev ? (
+            <Button variant="outline" size="sm" asChild>
+              <Link href={buildPageHref(filters, page - 1)} aria-label="Previous page">
+                <ChevronLeft className="h-4 w-4" aria-hidden />
+                Previous
+              </Link>
+            </Button>
+          ) : (
+            <Button variant="outline" size="sm" disabled aria-disabled="true">
+              <ChevronLeft className="h-4 w-4" aria-hidden />
+              Previous
+            </Button>
+          )}
+
+          {hasNext ? (
+            <Button variant="outline" size="sm" asChild>
+              <Link href={buildPageHref(filters, page + 1)} aria-label="Next page">
+                Next
+                <ChevronRight className="h-4 w-4" aria-hidden />
+              </Link>
+            </Button>
+          ) : (
+            <Button variant="outline" size="sm" disabled aria-disabled="true">
+              Next
+              <ChevronRight className="h-4 w-4" aria-hidden />
+            </Button>
+          )}
+        </div>
+      </nav>
+    </section>
+  )
+}

--- a/src/lib/feed/__tests__/queries.test.ts
+++ b/src/lib/feed/__tests__/queries.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for src/lib/feed/queries.ts
+ *
+ * Uses a hand-rolled Supabase query builder stub — no real DB needed.
+ * Tests:
+ *  - SELECT columns, ordering, range
+ *  - Permissive NULL filters (contract, seniority, geo_policy, salary_min)
+ *  - Error propagation
+ *  - Page offset math
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/src/lib/supabase/database.types'
+import { fetchFeedJobs, FEED_PAGE_SIZE } from '../queries'
+import type { FeedFilters } from '../schemas'
+
+// ---------------------------------------------------------------------------
+// Stub Supabase query builder
+// ---------------------------------------------------------------------------
+
+interface QueryState {
+  table: string
+  columns: string
+  filters: Array<{ method: string; args: unknown[] }>
+  rangeFrom: number
+  rangeTo: number
+}
+
+function buildStubClient(
+  returnData: unknown[] | null = [],
+  returnError: { message: string } | null = null,
+  returnCount: number | null = 0,
+): { supabase: SupabaseClient<Database>; state: QueryState } {
+  const state: QueryState = {
+    table: '',
+    columns: '',
+    filters: [],
+    rangeFrom: 0,
+    rangeTo: 0,
+  }
+
+  const asyncResult = Promise.resolve({
+    data: returnData,
+    error: returnError,
+    count: returnCount,
+  })
+
+  // Fluent chain — all methods return `chain` and record themselves
+  const chain: Record<string, unknown> = {}
+  const chainMethods = ['eq', 'or', 'order', 'range']
+  chainMethods.forEach((method) => {
+    chain[method] = (...args: unknown[]) => {
+      state.filters.push({ method, args })
+      if (method === 'range') {
+        state.rangeFrom = args[0] as number
+        state.rangeTo = args[1] as number
+      }
+      return chain
+    }
+  })
+  // Make chain thenable so `await query` works
+  chain.then = asyncResult.then.bind(asyncResult)
+  chain.catch = asyncResult.catch.bind(asyncResult)
+
+  const supabase = {
+    from: (table: string) => {
+      state.table = table
+      return {
+        select: (columns: string) => {
+          state.columns = columns
+          return chain
+        },
+      }
+    },
+  } as unknown as SupabaseClient<Database>
+
+  return { supabase, state }
+}
+
+// ---------------------------------------------------------------------------
+// Default filters (no active filters)
+// ---------------------------------------------------------------------------
+
+const defaultFilters: FeedFilters = {
+  page: 1,
+  contract: undefined,
+  seniority: undefined,
+  geo_policy: undefined,
+  salary_min: undefined,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('fetchFeedJobs', () => {
+  it('queries the jobs table', async () => {
+    const { supabase, state } = buildStubClient([], null, 0)
+    await fetchFeedJobs(supabase, defaultFilters, 1)
+    expect(state.table).toBe('jobs')
+  })
+
+  it('selects the expected columns', async () => {
+    const { supabase, state } = buildStubClient([], null, 0)
+    await fetchFeedJobs(supabase, defaultFilters, 1)
+    const cols = state.columns
+    expect(cols).toContain('id')
+    expect(cols).toContain('title')
+    expect(cols).toContain('company')
+    expect(cols).toContain('red_flags')
+    expect(cols).toContain('posted_at')
+    expect(cols).toContain('salary_min')
+    expect(cols).toContain('salary_max')
+    expect(cols).toContain('contract_type')
+  })
+
+  it('filters by status = active', async () => {
+    const { supabase, state } = buildStubClient([], null, 0)
+    await fetchFeedJobs(supabase, defaultFilters, 1)
+    const eqFilter = state.filters.find(
+      (f) => f.method === 'eq' && (f.args as string[])[0] === 'status',
+    )
+    expect(eqFilter).not.toBeUndefined()
+    expect((eqFilter!.args as string[])[1]).toBe('active')
+  })
+
+  it('sets correct range for page 1', async () => {
+    const { supabase, state } = buildStubClient([], null, 0)
+    await fetchFeedJobs(supabase, defaultFilters, 1)
+    expect(state.rangeFrom).toBe(0)
+    expect(state.rangeTo).toBe(FEED_PAGE_SIZE - 1)
+  })
+
+  it('sets correct range for page 2', async () => {
+    const { supabase, state } = buildStubClient([], null, 0)
+    await fetchFeedJobs(supabase, defaultFilters, 2)
+    expect(state.rangeFrom).toBe(FEED_PAGE_SIZE)
+    expect(state.rangeTo).toBe(FEED_PAGE_SIZE * 2 - 1)
+  })
+
+  it('clamps page < 1 to page 1 offset', async () => {
+    const { supabase, state } = buildStubClient([], null, 0)
+    await fetchFeedJobs(supabase, defaultFilters, 0)
+    expect(state.rangeFrom).toBe(0)
+  })
+
+  it('returns jobs array and total from DB', async () => {
+    const mockJobs = [
+      { id: 'a', title: 'Engineer', company: 'Acme', skills_required: [], red_flags: [], ingested_at: '2026-01-01' },
+    ]
+    const { supabase } = buildStubClient(mockJobs, null, 42)
+    const result = await fetchFeedJobs(supabase, defaultFilters, 1)
+    expect(result.jobs).toHaveLength(1)
+    expect(result.total).toBe(42)
+  })
+
+  it('returns empty array when data is null', async () => {
+    const { supabase } = buildStubClient(null, null, 0)
+    const result = await fetchFeedJobs(supabase, defaultFilters, 1)
+    expect(result.jobs).toEqual([])
+    expect(result.total).toBe(0)
+  })
+
+  it('throws on DB error', async () => {
+    const { supabase } = buildStubClient(null, { message: 'connection refused' }, null)
+    await expect(fetchFeedJobs(supabase, defaultFilters, 1)).rejects.toThrow(
+      'connection refused',
+    )
+  })
+
+  it('adds permissive OR filter for contract when set', async () => {
+    const { supabase, state } = buildStubClient([], null, 0)
+    await fetchFeedJobs(
+      supabase,
+      { ...defaultFilters, contract: 'contractor' },
+      1,
+    )
+    const orFilter = state.filters.find(
+      (f) =>
+        f.method === 'or' &&
+        typeof (f.args as string[])[0] === 'string' &&
+        ((f.args as string[])[0]).includes('contract_type'),
+    )
+    expect(orFilter).not.toBeUndefined()
+    const orArg = (orFilter!.args as string[])[0]
+    expect(orArg).toContain('contractor')
+    expect(orArg).toContain('null')
+  })
+
+  it('adds permissive OR filter for seniority when set', async () => {
+    const { supabase, state } = buildStubClient([], null, 0)
+    await fetchFeedJobs(
+      supabase,
+      { ...defaultFilters, seniority: 'senior' },
+      1,
+    )
+    const orFilter = state.filters.find(
+      (f) =>
+        f.method === 'or' &&
+        ((f.args as string[])[0]).includes('seniority'),
+    )
+    expect(orFilter).not.toBeUndefined()
+  })
+
+  it('adds permissive OR filter for geo_policy when set', async () => {
+    const { supabase, state } = buildStubClient([], null, 0)
+    await fetchFeedJobs(
+      supabase,
+      { ...defaultFilters, geo_policy: 'worldwide' },
+      1,
+    )
+    const orFilter = state.filters.find(
+      (f) =>
+        f.method === 'or' &&
+        ((f.args as string[])[0]).includes('geo_policy'),
+    )
+    expect(orFilter).not.toBeUndefined()
+  })
+
+  it('adds permissive OR filter for salary_min when set', async () => {
+    const { supabase, state } = buildStubClient([], null, 0)
+    await fetchFeedJobs(
+      supabase,
+      { ...defaultFilters, salary_min: 60000 },
+      1,
+    )
+    const orFilter = state.filters.find(
+      (f) =>
+        f.method === 'or' &&
+        ((f.args as string[])[0]).includes('salary_min'),
+    )
+    expect(orFilter).not.toBeUndefined()
+    expect((orFilter!.args as string[])[0]).toContain('60000')
+  })
+
+  it('does NOT add contract filter when contract is undefined', async () => {
+    const { supabase, state } = buildStubClient([], null, 0)
+    await fetchFeedJobs(supabase, { ...defaultFilters, contract: undefined }, 1)
+    const contractOrFilter = state.filters.find(
+      (f) =>
+        f.method === 'or' &&
+        ((f.args as string[])[0]).includes('contract_type'),
+    )
+    expect(contractOrFilter).toBeUndefined()
+  })
+})

--- a/src/lib/feed/__tests__/schemas.test.ts
+++ b/src/lib/feed/__tests__/schemas.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for src/lib/feed/schemas.ts
+ *
+ * Covers:
+ *  - Valid filter combinations
+ *  - Unknown / malformed values silently become undefined
+ *  - page coercion + default
+ *  - parseFeedFilters helper (array values, missing keys)
+ */
+
+import { describe, it, expect } from 'vitest'
+import { feedFiltersSchema, parseFeedFilters } from '../schemas'
+
+describe('feedFiltersSchema', () => {
+  it('parses empty object to defaults', () => {
+    const result = feedFiltersSchema.parse({})
+    expect(result.page).toBe(1)
+    expect(result.contract).toBeUndefined()
+    expect(result.seniority).toBeUndefined()
+    expect(result.geo_policy).toBeUndefined()
+    expect(result.salary_min).toBeUndefined()
+  })
+
+  it('parses valid filter values', () => {
+    const result = feedFiltersSchema.parse({
+      contract: 'contractor',
+      seniority: 'senior',
+      geo_policy: 'worldwide',
+      salary_min: 80000,
+      page: 3,
+    })
+    expect(result.contract).toBe('contractor')
+    expect(result.seniority).toBe('senior')
+    expect(result.geo_policy).toBe('worldwide')
+    expect(result.salary_min).toBe(80000)
+    expect(result.page).toBe(3)
+  })
+
+  it('silently coerces unknown contract value to undefined', () => {
+    const result = feedFiltersSchema.parse({ contract: 'invalid_value' })
+    expect(result.contract).toBeUndefined()
+  })
+
+  it('silently coerces unknown seniority value to undefined', () => {
+    const result = feedFiltersSchema.parse({ seniority: 'executive' })
+    expect(result.seniority).toBeUndefined()
+  })
+
+  it('silently coerces unknown geo_policy value to undefined', () => {
+    const result = feedFiltersSchema.parse({ geo_policy: 'moon' })
+    expect(result.geo_policy).toBeUndefined()
+  })
+
+  it('coerces string salary_min to number', () => {
+    const result = feedFiltersSchema.parse({ salary_min: '60000' })
+    expect(result.salary_min).toBe(60000)
+  })
+
+  it('silently sets salary_min to undefined for non-numeric string', () => {
+    const result = feedFiltersSchema.parse({ salary_min: 'not-a-number' })
+    expect(result.salary_min).toBeUndefined()
+  })
+
+  it('silently sets salary_min to undefined for negative value', () => {
+    const result = feedFiltersSchema.parse({ salary_min: -100 })
+    // negative fails min(0), catch returns undefined
+    expect(result.salary_min).toBeUndefined()
+  })
+
+  it('coerces string page to number and defaults to 1 for invalid', () => {
+    const result = feedFiltersSchema.parse({ page: 'abc' })
+    expect(result.page).toBe(1)
+  })
+
+  it('defaults page to 1 when missing', () => {
+    const result = feedFiltersSchema.parse({})
+    expect(result.page).toBe(1)
+  })
+
+  it('clamps page < 1 to 1 via catch', () => {
+    const result = feedFiltersSchema.parse({ page: 0 })
+    expect(result.page).toBe(1)
+  })
+})
+
+describe('parseFeedFilters', () => {
+  it('parses flat string record', () => {
+    const result = parseFeedFilters({
+      contract: 'employee',
+      seniority: 'mid',
+      page: '2',
+    })
+    expect(result.contract).toBe('employee')
+    expect(result.seniority).toBe('mid')
+    expect(result.page).toBe(2)
+  })
+
+  it('flattens array values (takes first element)', () => {
+    const result = parseFeedFilters({
+      contract: ['contractor', 'employee'],
+    })
+    expect(result.contract).toBe('contractor')
+  })
+
+  it('ignores undefined values', () => {
+    const result = parseFeedFilters({ contract: undefined })
+    expect(result.contract).toBeUndefined()
+  })
+
+  it('handles empty object gracefully', () => {
+    const result = parseFeedFilters({})
+    expect(result.page).toBe(1)
+  })
+
+  it('silently drops XSS-like values', () => {
+    const result = parseFeedFilters({ contract: '<script>alert(1)</script>' })
+    expect(result.contract).toBeUndefined()
+  })
+})

--- a/src/lib/feed/queries.ts
+++ b/src/lib/feed/queries.ts
@@ -1,0 +1,143 @@
+/**
+ * lib/feed/queries.ts — Feed query builder (Phase 1, no RPC).
+ *
+ * Phase 1: simple SELECT * FROM jobs WHERE status = 'active' ORDER BY posted_at DESC
+ * with permissive NULL-tolerant filters and keyset pagination.
+ *
+ * Columns tagged as AI-computed (red_flags, confidence_scores, seniority,
+ * contract_type, geo_policy, salary_min) can be NULL — every filter is
+ * written as `(col = :val OR col IS NULL)` so a NULL column passes all
+ * filters rather than being excluded.
+ *
+ * Architecture note: this is a pure domain function. It receives a Supabase
+ * client (already created with correct auth cookies by the Server Component)
+ * so it stays testable without mocking Next.js headers.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '@/src/lib/supabase/database.types'
+import type { FeedFilters } from './schemas'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const FEED_PAGE_SIZE = 20
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Shape returned for each row — subset of jobs columns safe for the feed. */
+export type FeedJob = {
+  id: string
+  title: string
+  company: string
+  logo_url: string | null
+  source_url: string
+  source: string
+  skills_required: string[]
+  salary_min: number | null
+  salary_max: number | null
+  salary_currency: string | null
+  salary_period: string | null
+  contract_type: string | null
+  geo_policy: string | null
+  seniority: string | null
+  red_flags: unknown // Json — validated permissively downstream
+  posted_at: string | null
+  ingested_at: string
+}
+
+export type FeedResult = {
+  jobs: FeedJob[]
+  /** Total count for pagination (estimated — Supabase count: 'exact'). */
+  total: number
+}
+
+// ---------------------------------------------------------------------------
+// Query builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch a page of active jobs with optional permissive filters.
+ *
+ * All AI-derived columns (contract_type, seniority, geo_policy, salary_min)
+ * default to "pass" when NULL — `(col = filter OR col IS NULL)`.
+ *
+ * Supabase's PostgREST does not support OR directly on a column in the
+ * query builder, so we use the `.or()` method.
+ *
+ * @param supabase - Authenticated Supabase client (server-side)
+ * @param filters  - Validated FeedFilters (from Zod schema)
+ * @param page     - 1-indexed page number
+ */
+export async function fetchFeedJobs(
+  supabase: SupabaseClient<Database>,
+  filters: FeedFilters,
+  page: number,
+): Promise<FeedResult> {
+  const offset = (Math.max(1, page) - 1) * FEED_PAGE_SIZE
+
+  let query = supabase
+    .from('jobs')
+    .select(
+      [
+        'id',
+        'title',
+        'company',
+        'logo_url',
+        'source_url',
+        'source',
+        'skills_required',
+        'salary_min',
+        'salary_max',
+        'salary_currency',
+        'salary_period',
+        'contract_type',
+        'geo_policy',
+        'seniority',
+        'red_flags',
+        'posted_at',
+        'ingested_at',
+      ].join(', '),
+      { count: 'exact' },
+    )
+    .eq('status', 'active')
+    .order('posted_at', { ascending: false, nullsFirst: false })
+    .order('ingested_at', { ascending: false }) // tie-break
+    .range(offset, offset + FEED_PAGE_SIZE - 1)
+
+  // -- Permissive filters: NULL columns pass all filters --------------------
+
+  if (filters.contract) {
+    // (contract_type = 'X' OR contract_type IS NULL)
+    query = query.or(`contract_type.eq.${filters.contract},contract_type.is.null`)
+  }
+
+  if (filters.seniority) {
+    query = query.or(`seniority.eq.${filters.seniority},seniority.is.null`)
+  }
+
+  if (filters.geo_policy) {
+    query = query.or(`geo_policy.eq.${filters.geo_policy},geo_policy.is.null`)
+  }
+
+  if (filters.salary_min != null) {
+    // salary_min >= threshold OR salary_min IS NULL (unknown salary passes)
+    query = query.or(
+      `salary_min.gte.${filters.salary_min},salary_min.is.null`,
+    )
+  }
+
+  const { data, error, count } = await query
+
+  if (error) {
+    throw new Error(`[feed] DB error: ${error.message}`)
+  }
+
+  return {
+    jobs: (data ?? []) as unknown as FeedJob[],
+    total: count ?? 0,
+  }
+}

--- a/src/lib/feed/schemas.ts
+++ b/src/lib/feed/schemas.ts
@@ -1,0 +1,71 @@
+/**
+ * lib/feed/schemas.ts — Zod validation for feed URL query params (filters).
+ *
+ * All filter fields are optional. Unknown / malformed values are silently
+ * coerced to undefined so a crafted URL never crashes the page.
+ *
+ * Phase 1 filter set (permissive on NULL — see queries.ts):
+ *   contract   — contractor | employee | both
+ *   seniority  — junior | mid | senior | lead | any
+ *   geo_policy — worldwide | specific_regions | specific_countries
+ *   salary_min — integer ≥ 0 (USD annual equivalent)
+ *   page       — integer ≥ 1 (default 1)
+ */
+
+import { z } from 'zod'
+
+// ---------------------------------------------------------------------------
+// Individual filter coercions
+// ---------------------------------------------------------------------------
+
+const contractEnum = z.enum(['contractor', 'employee', 'both'])
+const seniorityEnum = z.enum(['junior', 'mid', 'senior', 'lead', 'any'])
+const geoPolicyEnum = z.enum(['worldwide', 'specific_regions', 'specific_countries'])
+
+// coerce() ensures string query params like "20000" become numbers safely.
+const salaryMinSchema = z.coerce
+  .number()
+  .int()
+  .min(0)
+  .optional()
+  .catch(undefined)
+
+const pageSchema = z.coerce
+  .number()
+  .int()
+  .min(1)
+  .default(1)
+  .catch(1)
+
+// ---------------------------------------------------------------------------
+// Feed filters schema
+// ---------------------------------------------------------------------------
+
+export const feedFiltersSchema = z.object({
+  contract: contractEnum.optional().catch(undefined),
+  seniority: seniorityEnum.optional().catch(undefined),
+  geo_policy: geoPolicyEnum.optional().catch(undefined),
+  salary_min: salaryMinSchema,
+  page: pageSchema,
+})
+
+export type FeedFilters = z.infer<typeof feedFiltersSchema>
+
+// ---------------------------------------------------------------------------
+// Helper: parse raw searchParams (Next.js 16 async searchParams)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse raw search params (Record<string, string | string[] | undefined>)
+ * into validated FeedFilters. Always returns a valid object — never throws.
+ */
+export function parseFeedFilters(
+  raw: Record<string, string | string[] | undefined>,
+): FeedFilters {
+  // Flatten arrays: take first value only for each key
+  const flat: Record<string, string | undefined> = {}
+  for (const [k, v] of Object.entries(raw)) {
+    flat[k] = Array.isArray(v) ? v[0] : v
+  }
+  return feedFiltersSchema.parse(flat)
+}


### PR DESCRIPTION
## Summary

- `src/lib/feed/queries.ts` — `fetchFeedJobs(supabase, filters, page)` : SELECT direct sur `jobs WHERE status = 'active' ORDER BY posted_at DESC` avec filtres NULL-tolerants (`OR col IS NULL` pour chaque champ IA)
- `src/lib/feed/schemas.ts` — `parseFeedFilters()` : validation Zod des query params URL avec `.catch(undefined)` — valeur invalide = undefined, jamais de crash
- `components/feed/job-feed-list.tsx` — liste de JobCard + pagination Previous/Next par URL (`?page=N`)
- `components/feed/feed-filters.tsx` — 4 filtres (contract, seniority, geo_policy, salary_min) : sidebar desktop / Sheet drawer mobile, auto-submit onChange
- `app/(protected)/feed/page.tsx` — Server Component remplacant le stub EmptyState : async searchParams, onboarding guard, fetch DB, gestion erreur inline

## Acceptance criteria

- [x] Redirect vers /auth/login si non authentifie
- [x] Redirect vers /onboarding si onboarding_completed_at IS NULL
- [x] Jobs affiches tries par posted_at DESC
- [x] Colonnes IA NULL : pas de crash (red_flags, seniority, contract_type, geo_policy)
- [x] Filtres permissifs : (col = val OR col IS NULL)
- [x] Filtres persistes dans l'URL
- [x] Pagination 20/page via ?page=N
- [x] EmptyState si DB vide ou aucun resultat
- [x] Error fallback si requete echoue

## Tests

- 52 nouveaux tests unitaires (schemas + queries + composants) - 914/914 passent
- TypeScript 0 erreurs, ESLint 0 warnings, Build propre

## Hors scope (phase 2+)

Score IA, embedding, match_jobs_for_user(), bookmarks (issue #11), filtres avances (issue #10)
