### PR TITLE
[FM06+FM07] Badge 'Not analyzed' red flags + filtres feed (issue #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,21 @@ Filtres disponibles : contract type · seniority · location policy · minimum s
 |---|---|---|
 | Unit (Vitest) | `src/lib/feed/__tests__/schemas.test.ts` | parseFeedFilters — valeurs valides, coercions, XSS, defaults |
 | Unit (Vitest) | `src/lib/feed/__tests__/queries.test.ts` | fetchFeedJobs — colonnes, filtres NULL, pagination, erreurs |
-| Unit (Vitest) | `components/feed/__tests__/feed-components.test.tsx` | JobFeedList (empty states, pagination) + FeedFilters (options, badges) |
+| Unit (Vitest) | `components/feed/__tests__/feed-components.test.tsx` | JobFeedList (empty states, pagination, not-analyzed badge) + FeedFilters (options, badges) |
+| Unit (Vitest) | `components/jobs/__tests__/not-analyzed-badge.test.tsx` | NotAnalyzedBadge — rendu, label aria, title, icône |
+
+### Red flags (FM06)
+
+Le champ `jobs.red_flags` est un tableau JSON. En Phase 1, il est `NULL` (pas encore analysé par le pipeline IA).
+
+| État de `red_flags` | Affichage sur la JobCard |
+|---|---|
+| `NULL` (Phase 1) | Badge gris "Not analyzed" discret (horloge) |
+| `[]` (analysé, aucun flag) | Rien (job propre) |
+| `["raison 1", "raison 2"]` (Phase 2) | Badges rouges `RedFlagBadge` par flag |
+
+- `components/jobs/not-analyzed-badge.tsx` — badge secondaire gris, variant `secondary`, icône Clock
+- `components/jobs/red-flag-badge.tsx` — badge coral `red-flag`, icône AlertTriangle (existant depuis issue #16)
 
 ## Navigation mobile
 

--- a/components/feed/__tests__/feed-components.test.tsx
+++ b/components/feed/__tests__/feed-components.test.tsx
@@ -7,8 +7,8 @@
  * No jest-dom — use .not.toBeNull() / .not.toBeUndefined() etc.
  */
 
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
 import { JobFeedList } from '../job-feed-list'
 import { FeedFilters } from '../feed-filters'
 import type { FeedJob } from '@/src/lib/feed/queries'
@@ -21,6 +21,8 @@ import type { FeedFilters as FeedFiltersType } from '@/src/lib/feed/schemas'
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }))
+
+afterEach(() => cleanup())
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -164,6 +166,34 @@ describe('JobFeedList', () => {
         <JobFeedList jobs={[job]} total={1} page={1} filters={defaultFilters} />,
       ),
     ).not.toThrow()
+  })
+
+  it('shows "Not analyzed" badge when red_flags is null', () => {
+    const job = makeJob({ red_flags: null as unknown as [] })
+    render(
+      <JobFeedList jobs={[job]} total={1} page={1} filters={defaultFilters} />,
+    )
+    const badges = screen.getAllByText('Not analyzed')
+    expect(badges.length).toBeGreaterThan(0)
+  })
+
+  it('does NOT show "Not analyzed" badge when red_flags is a non-empty array', () => {
+    const job = makeJob({ red_flags: ['Unpaid trial'] })
+    render(
+      <JobFeedList jobs={[job]} total={1} page={1} filters={defaultFilters} />,
+    )
+    // Badge should not appear (job has been analyzed)
+    const badges = screen.queryAllByText('Not analyzed')
+    expect(badges.length).toBe(0)
+  })
+
+  it('does NOT show "Not analyzed" badge when red_flags is empty array (analyzed, no flags)', () => {
+    const job = makeJob({ red_flags: [] })
+    render(
+      <JobFeedList jobs={[job]} total={1} page={1} filters={defaultFilters} />,
+    )
+    const badges = screen.queryAllByText('Not analyzed')
+    expect(badges.length).toBe(0)
   })
 
   it('renders salary when both min and max present', () => {

--- a/components/feed/job-feed-list.tsx
+++ b/components/feed/job-feed-list.tsx
@@ -15,6 +15,7 @@
 import Link from 'next/link'
 import { Briefcase, ChevronLeft, ChevronRight } from 'lucide-react'
 import { JobCard } from '@/components/jobs/job-card'
+import { NotAnalyzedBadge } from '@/components/jobs/not-analyzed-badge'
 import { EmptyState } from '@/components/states/empty-state'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -49,11 +50,17 @@ function toJobCardData(job: FeedJob) {
   }
 
   // Parse red_flags — permissive: ignore if not array
+  // notAnalyzed = true when red_flags is NULL or an empty array (Phase 1)
   let redFlags: { reason: string }[] = []
+  let notAnalyzed = true
   if (Array.isArray(job.red_flags)) {
     redFlags = (job.red_flags as unknown[])
       .filter((f): f is string => typeof f === 'string')
       .map((reason) => ({ reason }))
+    // If the array exists (even empty), the field was set by extraction
+    // A non-null empty array means "analyzed, no flags found" — not "not analyzed"
+    // A null means "not yet processed by the AI pipeline" (Phase 1 default)
+    notAnalyzed = job.red_flags === null
   }
 
   // Format posted_at relative to today
@@ -78,6 +85,7 @@ function toJobCardData(job: FeedJob) {
     type: job.contract_type as 'contractor' | 'full-time' | undefined,
     tags: job.skills_required.slice(0, 6), // cap displayed tags
     redFlags: redFlags.length > 0 ? redFlags : undefined,
+    notAnalyzed,
   }
 }
 
@@ -136,11 +144,20 @@ export function JobFeedList({
     <section aria-label="Job listings" className={cn('flex flex-col gap-4', className)}>
       {/* -- Job cards ------------------------------------------------------- */}
       <ol className="flex flex-col gap-3 list-none p-0 m-0">
-        {jobs.map((job) => (
-          <li key={job.id}>
-            <JobCard job={toJobCardData(job)} variant="feed" />
-          </li>
-        ))}
+        {jobs.map((job) => {
+          const cardData = toJobCardData(job)
+          return (
+            <li key={job.id}>
+              <JobCard job={cardData} variant="feed" />
+              {/* Phase 1: show "Not analyzed" badge when red_flags is NULL */}
+              {cardData.notAnalyzed && !cardData.redFlags && (
+                <div className="px-1 pt-1.5">
+                  <NotAnalyzedBadge />
+                </div>
+              )}
+            </li>
+          )
+        })}
       </ol>
 
       {/* -- Pagination controls --------------------------------------------- */}

--- a/components/jobs/__tests__/not-analyzed-badge.test.tsx
+++ b/components/jobs/__tests__/not-analyzed-badge.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * Tests for NotAnalyzedBadge
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { NotAnalyzedBadge } from '../not-analyzed-badge'
+
+describe('NotAnalyzedBadge', () => {
+  it('renders without crashing', () => {
+    expect(() => render(<NotAnalyzedBadge />)).not.toThrow()
+  })
+
+  it('displays "Not analyzed" text', () => {
+    render(<NotAnalyzedBadge />)
+    const els = screen.getAllByText('Not analyzed')
+    expect(els.length).toBeGreaterThan(0)
+  })
+
+  it('has accessible label', () => {
+    render(<NotAnalyzedBadge />)
+    const badges = screen.getAllByLabelText('Red flags not yet analyzed')
+    expect(badges.length).toBeGreaterThan(0)
+  })
+
+  it('has a descriptive title attribute', () => {
+    render(<NotAnalyzedBadge />)
+    const badges = screen.getAllByLabelText('Red flags not yet analyzed')
+    const withTitle = badges.find((el) =>
+      (el.getAttribute('title') ?? '').includes('not yet been analyzed'),
+    )
+    expect(withTitle).not.toBeUndefined()
+  })
+
+  it('renders a clock icon (aria-hidden)', () => {
+    const { container } = render(<NotAnalyzedBadge />)
+    const svg = container.querySelector('svg[aria-hidden="true"]')
+    expect(svg).not.toBeNull()
+  })
+})

--- a/components/jobs/not-analyzed-badge.tsx
+++ b/components/jobs/not-analyzed-badge.tsx
@@ -1,0 +1,34 @@
+/**
+ * NotAnalyzedBadge — shown on job cards when red_flags has not yet been
+ * analyzed by the AI pipeline (Phase 1: red_flags is NULL or empty array).
+ *
+ * This badge is intentionally low-key (grey, secondary variant) to avoid
+ * alarming users — it simply signals that analysis is pending, not that
+ * there is a problem with the job.
+ *
+ * Phase 2: once the AI pipeline runs, this badge is replaced by actual
+ * RedFlagBadge components (or hidden if no flags were found).
+ */
+
+import { Clock } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+interface NotAnalyzedBadgeProps {
+  className?: string
+}
+
+export function NotAnalyzedBadge({ className }: NotAnalyzedBadgeProps) {
+  return (
+    <Badge
+      variant="secondary"
+      size="sm"
+      aria-label="Red flags not yet analyzed"
+      title="This job has not yet been analyzed for red flags"
+      className={cn('gap-1 text-text-muted', className)}
+    >
+      <Clock className="h-3 w-3 shrink-0" aria-hidden />
+      <span>Not analyzed</span>
+    </Badge>
+  )
+}


### PR DESCRIPTION
## Summary

- `components/jobs/not-analyzed-badge.tsx` — badge gris discret (variante `secondary`, icone Clock) affiche "Not analyzed" quand `red_flags` est NULL (Phase 1, pipeline IA pas encore execute)
- `components/feed/job-feed-list.tsx` — logique de detection : NULL = non analyse, `[]` = analyse sans flags, `[...]` = flags IA actifs
- Tests pour `NotAnalyzedBadge` (5 assertions) + 3 nouveaux tests dans `feed-components.test.tsx`

## Red flags behaviour

| `red_flags` value | Display |
|---|---|
| `NULL` (Phase 1 default) | Badge gris "Not analyzed" |
| `[]` (analyzed, clean) | Nothing |
| `["reason", ...]` (Phase 2) | RedFlagBadge par flag |

## Note scope

Les filtres du feed (contract, seniority, geo_policy, salary_min) ont ete implementes dans l'issue #9 (PR #54). Ce ticket couvre uniquement le delta FM06 : badge neutre quand red_flags est NULL.

## Tests

- 922/922 tests passent
- TypeScript 0 erreurs, ESLint 0 warnings, build propre
