### PR TITLE
[FM08+FM09] Bookmarks + apply tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,65 @@ Le champ `jobs.red_flags` est un tableau JSON. En Phase 1, il est `NULL` (pas en
 - `components/jobs/not-analyzed-badge.tsx` — badge secondaire gris, variant `secondary`, icône Clock
 - `components/jobs/red-flag-badge.tsx` — badge coral `red-flag`, icône AlertTriangle (existant depuis issue #16)
 
+## Bookmarks & tracking postulation (FM08 + FM09)
+
+### Sauvegarde d'offres (Bookmarks)
+
+Un utilisateur peut sauvegarder des offres depuis le feed, les retrouver sur `/saved`, et changer leur statut (candidature en cours, refus, etc.).
+
+**Flux** :
+1. `BookmarkButton` (Client Component, `useOptimistic`) sur chaque JobCard du feed.
+2. Clic → `saveJob(jobId)` ou `unsaveJob(jobId)` Server Action → INSERT/DELETE `saved_jobs`.
+3. `/saved` : liste triée par date, statut sélectionnable, bouton Postuler.
+4. Changement de statut → `updateSavedJobStatus(jobId, status)` Server Action.
+
+**Statuts disponibles** : `saved` · `applied` · `rejected` · `interviewing` · `offered`
+
+### Architecture
+
+```
+app/(protected)/saved/
+├── page.tsx              # Server Component — fetch saved_jobs JOIN jobs
+└── actions.ts            # saveJob, unsaveJob, updateSavedJobStatus
+
+components/jobs/
+├── bookmark-button.tsx   # Client Component — useOptimistic + saveJob/unsaveJob SA
+├── apply-button.tsx      # Client Component — lien nouvel onglet + sendBeacon
+└── saved-job-list.tsx    # Client Component — liste /saved avec select statut
+
+app/api/jobs/[id]/track-apply/
+└── route.ts              # POST → INSERT job_views action='click_apply' (204 No Content)
+
+components/feed/
+└── job-feed-list.tsx     # Reçoit savedJobIds (Set<string>) du SC, passe isBookmarked au BookmarkButton
+```
+
+### Tracking postulation
+
+Le clic sur "Apply" (depuis le feed ou `/saved`) :
+1. Ouvre `source_url` dans un nouvel onglet.
+2. Envoie `navigator.sendBeacon('/api/jobs/[id]/track-apply')` (fire-and-forget, fonctionnel même si la page se décharge).
+3. Le route handler insère `job_views { action: 'click_apply' }`.
+
+Pas de PostHog en Phase 1 — `job_views` est la seule source de tracking.
+
+### Sécurité
+
+- `getUser()` en début de chaque Server Action et du route handler — jamais de `user_id` client.
+- Validation Zod (UUID) sur `jobId` et enum sur `status`.
+- Écriture via `createClient()` (contexte user) → RLS s'applique.
+- Route handler : 401 si non authentifié, 400 si UUID invalide, 204 si succès.
+- `job_views` = audit records immuables : pas de politique UPDATE/DELETE dans les migrations.
+
+### Tests
+
+| Type | Fichier | Couverture |
+|---|---|---|
+| Unit (Vitest) | `app/(protected)/saved/__tests__/actions.test.ts` | saveJob, unsaveJob, updateSavedJobStatus — auth, Zod, DB errors, revalidatePath |
+| Unit (Vitest) | `components/jobs/__tests__/bookmark-apply.test.tsx` | BookmarkButton (aria, optimistic, toastError), ApplyButton (href, target, sendBeacon) |
+| Unit (Vitest) | `app/api/jobs/[id]/track-apply/__tests__/route.test.ts` | 401/400/204/500 — auth, UUID, insert, DB error |
+| pgTAP (SQL) | `supabase/tests/rls_job_views.sql` | Isolation SELECT/INSERT, cross-user DELETE impossible, aucune policy UPDATE/DELETE (5 assertions) |
+
 ## Navigation mobile
 
 Le `Header` affiche une navigation desktop (liens horizontaux) visible à partir du breakpoint `md` (768 px). En dessous, un drawer slide-in (bouton burger) prend le relais.

--- a/app/(protected)/feed/page.tsx
+++ b/app/(protected)/feed/page.tsx
@@ -44,14 +44,23 @@ export default async function FeedPage({
   const rawParams = await searchParams
   const filters = parseFeedFilters(rawParams)
 
-  // -- Fetch jobs ----------------------------------------------------------
+  // -- Fetch jobs + saved job IDs in parallel ------------------------------
   // We use the user-context client (row-level security active) so the
-  // `jobs_select_active` policy applies automatically.
+  // `jobs_select_active` policy and saved_jobs policies apply automatically.
   let feedResult: Awaited<ReturnType<typeof fetchFeedJobs>> | null = null
   let fetchError: string | null = null
+  let savedJobIds = new Set<string>()
 
   try {
-    feedResult = await fetchFeedJobs(userSupabase, filters, filters.page)
+    const [feedRes, savedRes] = await Promise.all([
+      fetchFeedJobs(userSupabase, filters, filters.page),
+      userSupabase
+        .from('saved_jobs')
+        .select('job_id')
+        .eq('user_id', user.id),
+    ])
+    feedResult = feedRes
+    savedJobIds = new Set((savedRes.data ?? []).map((r) => r.job_id))
   } catch (err) {
     console.error('[feed] fetch failed', err)
     fetchError = err instanceof Error ? err.message : 'Unknown error'
@@ -110,6 +119,7 @@ export default async function FeedPage({
                     total={feedResult?.total ?? 0}
                     page={filters.page}
                     filters={filters}
+                    savedJobIds={savedJobIds}
                   />
                 )}
               </div>

--- a/app/(protected)/saved/__tests__/actions.test.ts
+++ b/app/(protected)/saved/__tests__/actions.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for saved-jobs Server Actions (saveJob, unsaveJob, updateSavedJobStatus).
+ *
+ * Uses vi.hoisted mocks for Next.js (next/headers, next/navigation) and
+ * the Supabase server client — same pattern as onboarding/actions.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockGetUser,
+  mockFrom,
+  mockUpsert,
+  mockDelete,
+  mockUpdate,
+  mockRedirect,
+  mockRevalidatePath,
+} = vi.hoisted(() => {
+  const mockUpsert = vi.fn()
+  const mockDelete = vi.fn()
+  const mockUpdate = vi.fn()
+  const mockFrom = vi.fn()
+  const mockGetUser = vi.fn()
+  const mockRedirect = vi.fn()
+  const mockRevalidatePath = vi.fn()
+  return {
+    mockGetUser,
+    mockFrom,
+    mockUpsert,
+    mockDelete,
+    mockUpdate,
+    mockRedirect,
+    mockRevalidatePath,
+  }
+})
+
+vi.mock('next/navigation', () => ({ redirect: mockRedirect }))
+vi.mock('next/cache', () => ({ revalidatePath: mockRevalidatePath }))
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({ getAll: () => [], set: vi.fn() }),
+}))
+
+vi.mock('@/src/lib/auth/get-user', () => ({
+  getUser: mockGetUser,
+}))
+
+vi.mock('@/src/lib/supabase/server', () => ({
+  createClient: vi.fn().mockResolvedValue({
+    from: mockFrom,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Import actions AFTER mocks are set up
+// ---------------------------------------------------------------------------
+
+import { saveJob, unsaveJob, updateSavedJobStatus } from '../actions'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FAKE_USER = { id: 'user-uuid-123' }
+const FAKE_JOB_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+
+function setupAuthOk() {
+  mockGetUser.mockResolvedValue({ user: FAKE_USER })
+}
+
+function setupDeleteChain(error: null | { code: string; message: string }) {
+  const chainEq2 = vi.fn().mockResolvedValue({ error })
+  const chainEq1 = vi.fn().mockReturnValue({ eq: chainEq2 })
+  mockDelete.mockReturnValue({ eq: chainEq1 })
+  mockFrom.mockReturnValue({ delete: mockDelete })
+}
+
+function setupUpdateChain(error: null | { code: string; message: string }) {
+  const chainEq2 = vi.fn().mockResolvedValue({ error })
+  const chainEq1 = vi.fn().mockReturnValue({ eq: chainEq2 })
+  mockUpdate.mockReturnValue({ eq: chainEq1 })
+  mockFrom.mockReturnValue({ update: mockUpdate })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('saveJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('redirects to login when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ user: null })
+    mockRedirect.mockImplementation(() => { throw new Error('REDIRECT') })
+    await expect(saveJob(FAKE_JOB_ID)).rejects.toThrow('REDIRECT')
+    expect(mockRedirect).toHaveBeenCalledWith('/auth/login')
+  })
+
+  it('returns error for invalid UUID', async () => {
+    setupAuthOk()
+    const result = await saveJob('not-a-uuid')
+    expect(result).toMatchObject({ error: expect.stringContaining('Invalid') })
+  })
+
+  it('returns error for non-string input', async () => {
+    setupAuthOk()
+    const result = await saveJob(12345)
+    expect(result).toMatchObject({ error: expect.any(String) })
+  })
+
+  it('returns success on valid job id with upsert ok', async () => {
+    setupAuthOk()
+    mockUpsert.mockResolvedValue({ error: null })
+    mockFrom.mockReturnValue({ upsert: mockUpsert })
+    const result = await saveJob(FAKE_JOB_ID)
+    expect(result).toEqual({ success: true })
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: FAKE_USER.id, job_id: FAKE_JOB_ID, status: 'saved' }),
+      expect.objectContaining({ onConflict: 'user_id,job_id', ignoreDuplicates: true }),
+    )
+  })
+
+  it('returns error when DB upsert fails', async () => {
+    setupAuthOk()
+    mockUpsert.mockResolvedValue({ error: { code: '23505', message: 'dup' } })
+    mockFrom.mockReturnValue({ upsert: mockUpsert })
+    const result = await saveJob(FAKE_JOB_ID)
+    expect(result).toMatchObject({ error: expect.stringContaining('Failed to save') })
+  })
+
+  it('revalidates /feed and /saved on success', async () => {
+    setupAuthOk()
+    mockUpsert.mockResolvedValue({ error: null })
+    mockFrom.mockReturnValue({ upsert: mockUpsert })
+    await saveJob(FAKE_JOB_ID)
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/feed')
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/saved')
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('unsaveJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('redirects to login when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ user: null })
+    mockRedirect.mockImplementation(() => { throw new Error('REDIRECT') })
+    await expect(unsaveJob(FAKE_JOB_ID)).rejects.toThrow('REDIRECT')
+  })
+
+  it('returns error for invalid UUID', async () => {
+    setupAuthOk()
+    const result = await unsaveJob('bad-id')
+    expect(result).toMatchObject({ error: expect.any(String) })
+  })
+
+  it('returns success on valid delete', async () => {
+    setupAuthOk()
+    setupDeleteChain(null)
+    const result = await unsaveJob(FAKE_JOB_ID)
+    expect(result).toEqual({ success: true })
+  })
+
+  it('returns error when DB delete fails', async () => {
+    setupAuthOk()
+    setupDeleteChain({ code: '23503', message: 'fk' })
+    const result = await unsaveJob(FAKE_JOB_ID)
+    expect(result).toMatchObject({ error: expect.stringContaining('remove') })
+  })
+
+  it('revalidates /feed and /saved on success', async () => {
+    setupAuthOk()
+    setupDeleteChain(null)
+    await unsaveJob(FAKE_JOB_ID)
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/feed')
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/saved')
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('updateSavedJobStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('redirects to login when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ user: null })
+    mockRedirect.mockImplementation(() => { throw new Error('REDIRECT') })
+    await expect(updateSavedJobStatus(FAKE_JOB_ID, 'applied')).rejects.toThrow('REDIRECT')
+  })
+
+  it('returns error for invalid UUID', async () => {
+    setupAuthOk()
+    const result = await updateSavedJobStatus('bad-uuid', 'applied')
+    expect(result).toMatchObject({ error: expect.any(String) })
+  })
+
+  it('returns error for invalid status', async () => {
+    setupAuthOk()
+    const result = await updateSavedJobStatus(FAKE_JOB_ID, 'unknown_status')
+    expect(result).toMatchObject({ error: expect.any(String) })
+  })
+
+  it('accepts all valid statuses', async () => {
+    setupAuthOk()
+    setupUpdateChain(null)
+    for (const status of ['saved', 'applied', 'rejected', 'interviewing', 'offered']) {
+      vi.clearAllMocks()
+      setupAuthOk()
+      setupUpdateChain(null)
+      const result = await updateSavedJobStatus(FAKE_JOB_ID, status)
+      expect(result).toEqual({ success: true })
+    }
+  })
+
+  it('returns error when DB update fails', async () => {
+    setupAuthOk()
+    setupUpdateChain({ code: '42000', message: 'err' })
+    const result = await updateSavedJobStatus(FAKE_JOB_ID, 'applied')
+    expect(result).toMatchObject({ error: expect.any(String) })
+  })
+
+  it('revalidates /saved on success', async () => {
+    setupAuthOk()
+    setupUpdateChain(null)
+    await updateSavedJobStatus(FAKE_JOB_ID, 'applied')
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/saved')
+  })
+})

--- a/app/(protected)/saved/actions.ts
+++ b/app/(protected)/saved/actions.ts
@@ -1,0 +1,138 @@
+'use server'
+
+/**
+ * Saved-jobs Server Actions (FM08).
+ *
+ * Security guarantees:
+ *  1. Every action calls getUser() first — never trusts client-supplied user_id.
+ *  2. Input validated with Zod before any DB write.
+ *  3. DB writes use createClient() (user auth context) — RLS enforces ownership.
+ *
+ * Pattern: returns { success: true } | { error: string }.
+ */
+
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { z } from 'zod'
+import { getUser } from '@/src/lib/auth/get-user'
+import { createClient } from '@/src/lib/supabase/server'
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const jobIdSchema = z.string().uuid('Invalid job id.')
+
+const savedJobStatusSchema = z.enum(
+  ['saved', 'applied', 'rejected', 'interviewing', 'offered'],
+  { error: 'Invalid status.' },
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ActionResult = { success: true } | { error: string }
+
+async function getAuthenticatedUser() {
+  const { user } = await getUser()
+  if (!user) redirect('/auth/login')
+  return user
+}
+
+// ---------------------------------------------------------------------------
+// saveJob — INSERT saved_jobs row (idempotent via ON CONFLICT DO NOTHING)
+// ---------------------------------------------------------------------------
+
+export async function saveJob(jobId: unknown): Promise<ActionResult> {
+  const user = await getAuthenticatedUser()
+
+  const parsed = jobIdSchema.safeParse(jobId)
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid job id.' }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase.from('saved_jobs').upsert(
+    {
+      user_id: user.id,
+      job_id: parsed.data,
+      status: 'saved',
+    },
+    { onConflict: 'user_id,job_id', ignoreDuplicates: true },
+  )
+
+  if (error) {
+    console.error('[saved/saveJob] DB error:', error.code)
+    return { error: 'Failed to save job. Please try again.' }
+  }
+
+  revalidatePath('/feed')
+  revalidatePath('/saved')
+  return { success: true }
+}
+
+// ---------------------------------------------------------------------------
+// unsaveJob — DELETE saved_jobs row
+// ---------------------------------------------------------------------------
+
+export async function unsaveJob(jobId: unknown): Promise<ActionResult> {
+  const user = await getAuthenticatedUser()
+
+  const parsed = jobIdSchema.safeParse(jobId)
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid job id.' }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('saved_jobs')
+    .delete()
+    .eq('user_id', user.id)
+    .eq('job_id', parsed.data)
+
+  if (error) {
+    console.error('[saved/unsaveJob] DB error:', error.code)
+    return { error: 'Failed to remove bookmark. Please try again.' }
+  }
+
+  revalidatePath('/feed')
+  revalidatePath('/saved')
+  return { success: true }
+}
+
+// ---------------------------------------------------------------------------
+// updateSavedJobStatus — UPDATE status on a saved row
+// ---------------------------------------------------------------------------
+
+export async function updateSavedJobStatus(
+  jobId: unknown,
+  status: unknown,
+): Promise<ActionResult> {
+  const user = await getAuthenticatedUser()
+
+  const parsedId = jobIdSchema.safeParse(jobId)
+  if (!parsedId.success) {
+    return { error: parsedId.error.issues[0]?.message ?? 'Invalid job id.' }
+  }
+
+  const parsedStatus = savedJobStatusSchema.safeParse(status)
+  if (!parsedStatus.success) {
+    return { error: parsedStatus.error.issues[0]?.message ?? 'Invalid status.' }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('saved_jobs')
+    .update({ status: parsedStatus.data, updated_at: new Date().toISOString() })
+    .eq('user_id', user.id)
+    .eq('job_id', parsedId.data)
+
+  if (error) {
+    console.error('[saved/updateStatus] DB error:', error.code)
+    return { error: 'Failed to update status. Please try again.' }
+  }
+
+  revalidatePath('/saved')
+  return { success: true }
+}

--- a/app/(protected)/saved/page.tsx
+++ b/app/(protected)/saved/page.tsx
@@ -1,0 +1,118 @@
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import { Bookmark } from 'lucide-react'
+import { getUserWithProfile } from '@/src/lib/auth/get-user'
+import { Header } from '@/components/layout/header'
+import { Footer } from '@/components/layout/footer'
+import { EmptyState } from '@/components/states/empty-state'
+import { SavedJobList } from '@/components/jobs/saved-job-list'
+
+export const metadata: Metadata = {
+  title: 'Saved jobs — JobNomad',
+  description: 'Your bookmarked remote job listings.',
+}
+
+/**
+ * /saved — Authenticated saved-jobs page (FM08).
+ *
+ * Guards: not authenticated → /auth/login, onboarding pending → /onboarding.
+ *
+ * Architecture:
+ *  - Server Component: fetches saved_jobs JOIN jobs, passes data to
+ *    SavedJobList (Client Component handles status updates + unsave).
+ *  - RLS: only the authenticated user's rows are returned automatically.
+ */
+export default async function SavedPage() {
+  const { user, profile, supabase } = await getUserWithProfile()
+
+  if (!user) redirect('/auth/login')
+  if (!profile?.onboarding_completed_at) redirect('/onboarding')
+
+  // Fetch saved jobs with job details, newest first
+  const { data: savedJobs, error } = await supabase
+    .from('saved_jobs')
+    .select(
+      `
+      id,
+      job_id,
+      status,
+      saved_at,
+      updated_at,
+      jobs (
+        id,
+        title,
+        company,
+        source_url,
+        salary_min,
+        salary_max,
+        salary_currency,
+        salary_period,
+        contract_type,
+        skills_required,
+        posted_at
+      )
+    `,
+    )
+    .order('saved_at', { ascending: false })
+    .limit(100)
+
+  if (error) {
+    console.error('[saved] fetch error:', error.code)
+  }
+
+  const items = (savedJobs ?? []).filter((row) => row.jobs !== null)
+
+  return (
+    <div className="flex flex-col flex-1 bg-bg text-text">
+      <Header variant="app" userEmail={user.email} />
+
+      <main id="main" className="flex flex-col flex-1 px-4 sm:px-6 py-8">
+        <div className="mx-auto w-full max-w-3xl">
+          <div className="mb-6">
+            <h1 className="text-display-lg text-text">Saved jobs</h1>
+            <p className="text-body-md text-text-soft mt-1">
+              {items.length > 0
+                ? `${items.length} saved job${items.length !== 1 ? 's' : ''}`
+                : 'Jobs you bookmark appear here.'}
+            </p>
+          </div>
+
+          {items.length === 0 ? (
+            <EmptyState
+              icon={Bookmark}
+              heading="No saved jobs yet"
+              description="Bookmark jobs from your feed to review later."
+              action={{ label: 'Browse jobs', href: '/feed' }}
+            />
+          ) : (
+            <SavedJobList items={items as SavedJobItem[]} />
+          )}
+        </div>
+      </main>
+
+      <Footer variant="minimal" />
+    </div>
+  )
+}
+
+// Re-export type so SavedJobList can import it
+export type SavedJobItem = {
+  id: string
+  job_id: string
+  status: string
+  saved_at: string
+  updated_at: string
+  jobs: {
+    id: string
+    title: string
+    company: string
+    source_url: string
+    salary_min: number | null
+    salary_max: number | null
+    salary_currency: string | null
+    salary_period: string | null
+    contract_type: string | null
+    skills_required: string[]
+    posted_at: string | null
+  }
+}

--- a/app/api/jobs/[id]/track-apply/__tests__/route.test.ts
+++ b/app/api/jobs/[id]/track-apply/__tests__/route.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for POST /api/jobs/[id]/track-apply route handler.
+ *
+ * Mocks Supabase user-context client and getUser.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const mockInsert = vi.fn()
+const mockFrom = vi.fn()
+const mockGetUser = vi.fn()
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({ getAll: () => [], set: vi.fn() }),
+}))
+
+vi.mock('@/src/lib/auth/get-user', () => ({
+  getUser: mockGetUser,
+}))
+
+vi.mock('@/src/lib/supabase/server', () => ({
+  createClient: vi.fn().mockResolvedValue({
+    from: mockFrom,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { POST } = await import('../route')
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FAKE_USER = { id: 'user-uuid-abc' }
+const VALID_JOB_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/jobs/' + VALID_JOB_ID + '/track-apply', {
+    method: 'POST',
+  })
+}
+
+async function makeParams(id: string) {
+  return Promise.resolve({ id })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/jobs/[id]/track-apply', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ user: null })
+    const res = await POST(makeRequest(), { params: makeParams(VALID_JOB_ID) })
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body).toMatchObject({ error: 'Unauthorized' })
+  })
+
+  it('returns 400 for invalid UUID', async () => {
+    mockGetUser.mockResolvedValue({ user: FAKE_USER })
+    const res = await POST(makeRequest(), { params: makeParams('not-a-uuid') })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body).toMatchObject({ error: 'Invalid job id.' })
+  })
+
+  it('returns 204 on success', async () => {
+    mockGetUser.mockResolvedValue({ user: FAKE_USER })
+    mockInsert.mockResolvedValue({ error: null })
+    mockFrom.mockReturnValue({ insert: mockInsert })
+    const res = await POST(makeRequest(), { params: makeParams(VALID_JOB_ID) })
+    expect(res.status).toBe(204)
+  })
+
+  it('inserts correct record in job_views', async () => {
+    mockGetUser.mockResolvedValue({ user: FAKE_USER })
+    mockInsert.mockResolvedValue({ error: null })
+    mockFrom.mockReturnValue({ insert: mockInsert })
+    await POST(makeRequest(), { params: makeParams(VALID_JOB_ID) })
+    expect(mockFrom).toHaveBeenCalledWith('job_views')
+    expect(mockInsert).toHaveBeenCalledWith({
+      user_id: FAKE_USER.id,
+      job_id: VALID_JOB_ID,
+      action: 'click_apply',
+    })
+  })
+
+  it('returns 500 on DB error', async () => {
+    mockGetUser.mockResolvedValue({ user: FAKE_USER })
+    mockInsert.mockResolvedValue({ error: { code: '23503', message: 'fk violation' } })
+    mockFrom.mockReturnValue({ insert: mockInsert })
+    const res = await POST(makeRequest(), { params: makeParams(VALID_JOB_ID) })
+    expect(res.status).toBe(500)
+  })
+})

--- a/app/api/jobs/[id]/track-apply/route.ts
+++ b/app/api/jobs/[id]/track-apply/route.ts
@@ -1,0 +1,60 @@
+/**
+ * POST /api/jobs/[id]/track-apply
+ *
+ * Inserts a job_views row with action='click_apply'.
+ * Called via navigator.sendBeacon from ApplyButton — expects no body.
+ *
+ * Security:
+ *  - Authenticates via Supabase session cookie (getUser).
+ *  - Validates job id with Zod (UUID).
+ *  - Uses user-context client (RLS applies: insert_own policy).
+ *  - Rate-limited implicitly via RLS insert policy (no hard limit in Phase 1).
+ *
+ * Response:
+ *  - 204 No Content on success (sendBeacon ignores response body).
+ *  - 401 if not authenticated.
+ *  - 400 if id is not a valid UUID.
+ *  - 500 on DB error (logged, not surfaced to client).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { getUser } from '@/src/lib/auth/get-user'
+import { createClient } from '@/src/lib/supabase/server'
+
+const jobIdSchema = z.string().uuid()
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  // -- Auth ----------------------------------------------------------------
+  const { user } = await getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // -- Validate params (Next.js 16: params is a Promise) -------------------
+  const { id } = await params
+  const parsed = jobIdSchema.safeParse(id)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid job id.' }, { status: 400 })
+  }
+
+  // -- Insert job_views row ------------------------------------------------
+  const supabase = await createClient()
+  const { error } = await supabase.from('job_views').insert({
+    user_id: user.id,
+    job_id: parsed.data,
+    action: 'click_apply',
+  })
+
+  if (error) {
+    // Log for observability but do not expose DB details to client
+    console.error('[track-apply] DB error:', error.code, error.message)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+
+  // 204 No Content — sendBeacon ignores the response body anyway
+  return new NextResponse(null, { status: 204 })
+}

--- a/components/feed/job-feed-list.tsx
+++ b/components/feed/job-feed-list.tsx
@@ -16,6 +16,8 @@ import Link from 'next/link'
 import { Briefcase, ChevronLeft, ChevronRight } from 'lucide-react'
 import { JobCard } from '@/components/jobs/job-card'
 import { NotAnalyzedBadge } from '@/components/jobs/not-analyzed-badge'
+import { BookmarkButton } from '@/components/jobs/bookmark-button'
+import { ApplyButton } from '@/components/jobs/apply-button'
 import { EmptyState } from '@/components/states/empty-state'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -112,6 +114,8 @@ interface JobFeedListProps {
   total: number
   page: number
   filters: FeedFilters
+  /** Set of job UUIDs the current user has already bookmarked. */
+  savedJobIds?: Set<string>
   className?: string
 }
 
@@ -120,6 +124,7 @@ export function JobFeedList({
   total,
   page,
   filters,
+  savedJobIds = new Set(),
   className,
 }: JobFeedListProps) {
   const totalPages = Math.max(1, Math.ceil(total / FEED_PAGE_SIZE))
@@ -146,13 +151,32 @@ export function JobFeedList({
       <ol className="flex flex-col gap-3 list-none p-0 m-0">
         {jobs.map((job) => {
           const cardData = toJobCardData(job)
+          const isBookmarked = savedJobIds.has(job.id)
           return (
-            <li key={job.id}>
+            <li key={job.id} className="relative">
+              {/* Bookmark button — absolute top-right, overlays the card */}
+              <div className="absolute top-3 right-3 z-10">
+                <BookmarkButton jobId={job.id} isBookmarked={isBookmarked} />
+              </div>
+
               <JobCard job={cardData} variant="feed" />
+
               {/* Phase 1: show "Not analyzed" badge when red_flags is NULL */}
               {cardData.notAnalyzed && !cardData.redFlags && (
                 <div className="px-1 pt-1.5">
                   <NotAnalyzedBadge />
+                </div>
+              )}
+
+              {/* Apply button row (only if source_url available) */}
+              {job.source_url && (
+                <div className="mt-1 flex justify-end px-1">
+                  <ApplyButton
+                    jobId={job.id}
+                    applyUrl={job.source_url}
+                    title={job.title}
+                    company={job.company}
+                  />
                 </div>
               )}
             </li>

--- a/components/jobs/__tests__/bookmark-apply.test.tsx
+++ b/components/jobs/__tests__/bookmark-apply.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Tests for BookmarkButton and ApplyButton components.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+afterEach(() => cleanup())
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockSaveJob = vi.fn().mockResolvedValue({ success: true })
+const mockUnsaveJob = vi.fn().mockResolvedValue({ success: true })
+const mockToastError = vi.fn()
+
+vi.mock('@/app/(protected)/saved/actions', () => ({
+  saveJob: (...args: unknown[]) => mockSaveJob(...args),
+  unsaveJob: (...args: unknown[]) => mockUnsaveJob(...args),
+  updateSavedJobStatus: vi.fn().mockResolvedValue({ success: true }),
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toastError: (...args: unknown[]) => mockToastError(...args),
+}))
+
+import { BookmarkButton } from '../bookmark-button'
+import { ApplyButton } from '../apply-button'
+
+// ---------------------------------------------------------------------------
+// BookmarkButton
+// ---------------------------------------------------------------------------
+
+describe('BookmarkButton', () => {
+  it('renders with aria-label "Bookmark this job" when not bookmarked', () => {
+    render(<BookmarkButton jobId="job-1" isBookmarked={false} />)
+    const btn = screen.getByRole('button', { name: /bookmark this job/i })
+    expect(btn).not.toBeNull()
+  })
+
+  it('renders with aria-label "Remove bookmark" when bookmarked', () => {
+    render(<BookmarkButton jobId="job-1" isBookmarked={true} />)
+    const btn = screen.getByRole('button', { name: /remove bookmark/i })
+    expect(btn).not.toBeNull()
+  })
+
+  it('has aria-pressed=false when not bookmarked', () => {
+    render(<BookmarkButton jobId="job-1" isBookmarked={false} />)
+    const btn = screen.getByRole('button', { name: /bookmark this job/i })
+    expect(btn.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('has aria-pressed=true when bookmarked', () => {
+    render(<BookmarkButton jobId="job-1" isBookmarked={true} />)
+    const btn = screen.getByRole('button', { name: /remove bookmark/i })
+    expect(btn.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('calls saveJob when clicking to bookmark (not bookmarked)', async () => {
+    render(<BookmarkButton jobId="job-42" isBookmarked={false} />)
+    const btn = screen.getByRole('button', { name: /bookmark this job/i })
+    fireEvent.click(btn)
+    // Give the async transition a tick
+    await new Promise((r) => setTimeout(r, 10))
+    expect(mockSaveJob).toHaveBeenCalledWith('job-42')
+  })
+
+  it('calls unsaveJob when clicking to remove (bookmarked)', async () => {
+    render(<BookmarkButton jobId="job-99" isBookmarked={true} />)
+    const btn = screen.getByRole('button', { name: /remove bookmark/i })
+    fireEvent.click(btn)
+    await new Promise((r) => setTimeout(r, 10))
+    expect(mockUnsaveJob).toHaveBeenCalledWith('job-99')
+  })
+
+  it('calls toastError when saveJob returns error', async () => {
+    mockSaveJob.mockResolvedValueOnce({ error: 'Save failed' })
+    render(<BookmarkButton jobId="job-err" isBookmarked={false} />)
+    const btn = screen.getByRole('button', { name: /bookmark this job/i })
+    fireEvent.click(btn)
+    await new Promise((r) => setTimeout(r, 20))
+    expect(mockToastError).toHaveBeenCalledWith('Save failed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ApplyButton
+// ---------------------------------------------------------------------------
+
+describe('ApplyButton', () => {
+  it('renders a link with the apply URL', () => {
+    render(
+      <ApplyButton
+        jobId="job-1"
+        applyUrl="https://example.com/apply"
+        title="Engineer"
+        company="Acme"
+      />,
+    )
+    const link = screen.getByRole('link', { name: /apply to engineer at acme/i })
+    expect(link).not.toBeNull()
+    expect(link.getAttribute('href')).toBe('https://example.com/apply')
+  })
+
+  it('opens in a new tab (target=_blank)', () => {
+    render(
+      <ApplyButton
+        jobId="job-1"
+        applyUrl="https://example.com/apply"
+        title="Engineer"
+        company="Acme"
+      />,
+    )
+    const link = screen.getByRole('link', { name: /apply to engineer at acme/i })
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toContain('noopener')
+  })
+
+  it('fires sendBeacon on click', () => {
+    const mockBeacon = vi.fn()
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: mockBeacon,
+      writable: true,
+    })
+
+    render(
+      <ApplyButton
+        jobId="job-beacon"
+        applyUrl="https://example.com/apply"
+        title="Engineer"
+        company="Acme"
+      />,
+    )
+    const link = screen.getByRole('link', { name: /apply to engineer at acme/i })
+    fireEvent.click(link)
+    expect(mockBeacon).toHaveBeenCalledWith('/api/jobs/job-beacon/track-apply')
+  })
+
+  it('renders with correct aria-label including (opens in new tab)', () => {
+    render(
+      <ApplyButton
+        jobId="job-1"
+        applyUrl="https://example.com/apply"
+        title="Senior Dev"
+        company="StartupCo"
+      />,
+    )
+    const link = screen.getByRole('link', {
+      name: /apply to senior dev at startupco.*opens in new tab/i,
+    })
+    expect(link).not.toBeNull()
+  })
+})

--- a/components/jobs/apply-button.tsx
+++ b/components/jobs/apply-button.tsx
@@ -1,0 +1,61 @@
+/**
+ * ApplyButton — opens the job's source URL in a new tab and fires a
+ * click_apply tracking event via navigator.sendBeacon (fire-and-forget,
+ * works even when the page is being unloaded).
+ *
+ * The beacon hits /api/jobs/[id]/track-apply which inserts a row in
+ * job_views with action='click_apply'.  No PostHog in Phase 1.
+ *
+ * Props:
+ *   jobId    — UUID of the job
+ *   applyUrl — source_url from jobs table
+ *   title    — used for aria-label
+ *   company  — used for aria-label
+ *   size     — Button size prop (default 'sm')
+ */
+
+'use client'
+
+import { ExternalLink } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface ApplyButtonProps {
+  jobId: string
+  applyUrl: string
+  title: string
+  company: string
+  size?: 'sm' | 'default' | 'lg' | 'icon'
+}
+
+export function ApplyButton({
+  jobId,
+  applyUrl,
+  title,
+  company,
+  size = 'sm',
+}: ApplyButtonProps) {
+  function handleClick() {
+    // Fire-and-forget beacon — works even if the tab navigates away
+    if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
+      navigator.sendBeacon(`/api/jobs/${jobId}/track-apply`)
+    }
+  }
+
+  return (
+    <Button
+      size={size}
+      asChild
+      onClick={handleClick}
+    >
+      <a
+        href={applyUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`Apply to ${title} at ${company} (opens in new tab)`}
+      >
+        Apply
+        <ExternalLink className="h-3 w-3" aria-hidden />
+      </a>
+    </Button>
+  )
+}

--- a/components/jobs/bookmark-button.tsx
+++ b/components/jobs/bookmark-button.tsx
@@ -1,0 +1,66 @@
+/**
+ * BookmarkButton — optimistic bookmark toggle for a job.
+ *
+ * Uses React's useOptimistic to immediately reflect the new state in the UI,
+ * then calls the Server Action in the background. On failure, the optimistic
+ * state is rolled back and a toast error is shown.
+ *
+ * Props:
+ *   jobId       — UUID of the job
+ *   isBookmarked — current persisted state (from DB, fetched in parent SC)
+ *   className   — optional Tailwind classes
+ */
+
+'use client'
+
+import { useOptimistic, useTransition } from 'react'
+import { Bookmark } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { toastError } from '@/lib/toast'
+import { saveJob, unsaveJob } from '@/app/(protected)/saved/actions'
+import { cn } from '@/lib/utils'
+
+interface BookmarkButtonProps {
+  jobId: string
+  isBookmarked: boolean
+  className?: string
+}
+
+export function BookmarkButton({
+  jobId,
+  isBookmarked,
+  className,
+}: BookmarkButtonProps) {
+  const [optimisticBookmarked, setOptimisticBookmarked] = useOptimistic(isBookmarked)
+  const [, startTransition] = useTransition()
+
+  function handleClick() {
+    const next = !optimisticBookmarked
+    startTransition(async () => {
+      setOptimisticBookmarked(next)
+      const result = next ? await saveJob(jobId) : await unsaveJob(jobId)
+      if ('error' in result) {
+        // Roll back is automatic (optimistic state tied to transition)
+        toastError(result.error)
+      }
+    })
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={cn('h-7 w-7 text-text-muted hover:text-primary', className)}
+      aria-label={optimisticBookmarked ? 'Remove bookmark' : 'Bookmark this job'}
+      aria-pressed={optimisticBookmarked}
+      onClick={handleClick}
+    >
+      <Bookmark
+        className={cn(
+          'h-4 w-4',
+          optimisticBookmarked && 'fill-primary text-primary',
+        )}
+      />
+    </Button>
+  )
+}

--- a/components/jobs/saved-job-list.tsx
+++ b/components/jobs/saved-job-list.tsx
@@ -1,0 +1,136 @@
+/**
+ * SavedJobList — client component that renders the list of saved jobs.
+ *
+ * Each row shows:
+ *  - Job title + company
+ *  - Status select (saved / applied / rejected / interviewing / offered)
+ *  - ApplyButton (opens source_url + fires tracking beacon)
+ *  - BookmarkButton (unsave = remove bookmark)
+ *
+ * Optimistic updates are handled inside BookmarkButton (useOptimistic).
+ * Status changes call updateSavedJobStatus Server Action directly via
+ * a <form> select — no extra client state needed.
+ */
+
+'use client'
+
+import { BookmarkButton } from './bookmark-button'
+import { ApplyButton } from './apply-button'
+import { updateSavedJobStatus } from '@/app/(protected)/saved/actions'
+import { toastError } from '@/lib/toast'
+import type { SavedJobItem } from '@/app/(protected)/saved/page'
+
+const STATUS_LABELS: Record<string, string> = {
+  saved: 'Saved',
+  applied: 'Applied',
+  rejected: 'Rejected',
+  interviewing: 'Interviewing',
+  offered: 'Offered',
+}
+
+interface SavedJobListProps {
+  items: SavedJobItem[]
+}
+
+export function SavedJobList({ items }: SavedJobListProps) {
+  async function handleStatusChange(jobId: string, status: string) {
+    const result = await updateSavedJobStatus(jobId, status)
+    if ('error' in result) {
+      toastError(result.error)
+    }
+  }
+
+  return (
+    <ol className="flex flex-col gap-3 list-none p-0 m-0">
+      {items.map((item) => {
+        const job = item.jobs
+
+        // Build salary string
+        let salary: string | undefined
+        if (job.salary_min != null || job.salary_max != null) {
+          const currency = job.salary_currency ?? 'USD'
+          const period = job.salary_period ?? 'year'
+          const fmt = (n: number) =>
+            new Intl.NumberFormat('en-US', {
+              style: 'currency',
+              currency,
+              maximumFractionDigits: 0,
+            }).format(n)
+          if (job.salary_min != null && job.salary_max != null) {
+            salary = `${fmt(job.salary_min)} – ${fmt(job.salary_max)} / ${period}`
+          } else if (job.salary_min != null) {
+            salary = `From ${fmt(job.salary_min)} / ${period}`
+          } else if (job.salary_max != null) {
+            salary = `Up to ${fmt(job.salary_max)} / ${period}`
+          }
+        }
+
+        return (
+          <li
+            key={item.id}
+            className="flex flex-col gap-3 rounded-lg border border-border bg-surface p-4 sm:p-5 shadow-xs"
+          >
+            {/* Header */}
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <p className="text-overline text-text-muted truncate">{job.company}</p>
+                <h3 className="text-display-sm text-text">{job.title}</h3>
+              </div>
+
+              {/* Bookmark (unsave) button */}
+              <BookmarkButton
+                jobId={item.job_id}
+                isBookmarked={true}
+                className="shrink-0"
+              />
+            </div>
+
+            {/* Tags (top 4 skills) */}
+            {job.skills_required.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {job.skills_required.slice(0, 4).map((skill) => (
+                  <span
+                    key={skill}
+                    className="inline-flex items-center rounded-full border border-border px-2 py-0.5 text-mono-xs text-text-muted"
+                  >
+                    {skill}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Footer: salary + status + apply */}
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3 min-w-0">
+                {salary && (
+                  <span className="text-label-md text-text-soft shrink-0">{salary}</span>
+                )}
+
+                {/* Status select */}
+                <select
+                  defaultValue={item.status}
+                  aria-label={`Application status for ${job.title}`}
+                  className="rounded-md border border-border bg-surface px-2 py-1 text-body-sm text-text focus:outline-none focus:ring-2 focus:ring-primary"
+                  onChange={(e) => handleStatusChange(item.job_id, e.target.value)}
+                >
+                  {Object.entries(STATUS_LABELS).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <ApplyButton
+                jobId={item.job_id}
+                applyUrl={job.source_url}
+                title={job.title}
+                company={job.company}
+              />
+            </div>
+          </li>
+        )
+      })}
+    </ol>
+  )
+}

--- a/supabase/tests/rls_job_views.sql
+++ b/supabase/tests/rls_job_views.sql
@@ -1,0 +1,122 @@
+-- =============================================================================
+-- RLS Tests: job_views
+-- Verifies cross-user isolation and immutability (no UPDATE/DELETE policies).
+-- job_views are audit records: only the owning user can SELECT or INSERT.
+-- No UPDATE or DELETE is permitted for any authenticated user.
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(5);
+
+DO $$
+DECLARE
+  v_user_a UUID := gen_random_uuid();
+  v_user_b UUID := gen_random_uuid();
+  v_job_id UUID;
+  v_a_can_see      INTEGER;
+  v_b_can_see_a    INTEGER;
+  v_b_inserted     INTEGER;
+  v_rows_after_del INTEGER;
+BEGIN
+  -- Setup
+  INSERT INTO auth.users (id, email, encrypted_password, email_confirmed_at, created_at, updated_at)
+  VALUES
+    (v_user_a, 'views_a@jobnomad.test', 'x', now(), now(), now()),
+    (v_user_b, 'views_b@jobnomad.test', 'x', now(), now(), now());
+
+  INSERT INTO public.jobs (source, source_url, title, company, description, status, hash_dedup)
+  VALUES ('remoteok', 'https://remoteok.com/views-rls-test', 'Views RLS Job', 'ViewsCo',
+          'Description for RLS test', 'active',
+          encode(digest('views-rls-job', 'sha256'), 'hex'))
+  RETURNING id INTO v_job_id;
+
+  -- User A inserts a view (using authenticated role + JWT claims)
+  SET LOCAL role = 'authenticated';
+  PERFORM set_config('request.jwt.claims', concat('{"sub":"', v_user_a, '"}'), true);
+
+  INSERT INTO public.job_views (user_id, job_id, action)
+  VALUES (v_user_a, v_job_id, 'click_apply');
+
+  -- Test 1: User A can SELECT own views
+  SELECT COUNT(*) INTO v_a_can_see
+    FROM public.job_views WHERE user_id = v_user_a;
+
+  -- Test 2: User B CANNOT see User A's views
+  PERFORM set_config('request.jwt.claims', concat('{"sub":"', v_user_b, '"}'), true);
+
+  SELECT COUNT(*) INTO v_b_can_see_a
+    FROM public.job_views WHERE user_id = v_user_a;
+
+  -- Test 3: User B cannot INSERT a view with user_id = user_a (RLS blocks)
+  BEGIN
+    INSERT INTO public.job_views (user_id, job_id, action)
+    VALUES (v_user_a, v_job_id, 'view');
+    -- If we reach here, the INSERT succeeded (should not happen)
+    v_b_inserted := 1;
+  EXCEPTION WHEN others THEN
+    v_b_inserted := 0;
+  END;
+
+  -- Test 4: User B cannot DELETE User A's views
+  -- RLS will silently filter the DELETE; verify from service_role
+  DELETE FROM public.job_views WHERE user_id = v_user_a;
+
+  RESET role;
+  PERFORM set_config('request.jwt.claims', '', true);
+
+  SELECT COUNT(*) INTO v_rows_after_del
+    FROM public.job_views WHERE user_id = v_user_a;
+
+  CREATE TEMP TABLE _rls_job_views_ctx (
+    a_can_see      INTEGER,
+    b_can_see_a    INTEGER,
+    b_inserted     INTEGER,
+    rows_after_del INTEGER
+  ) ON COMMIT DROP;
+
+  INSERT INTO _rls_job_views_ctx
+    VALUES (v_a_can_see, v_b_can_see_a, v_b_inserted, v_rows_after_del);
+
+  DELETE FROM auth.users WHERE id IN (v_user_a, v_user_b);
+END;
+$$;
+
+SELECT is(
+  (SELECT a_can_see FROM _rls_job_views_ctx),
+  1,
+  'User A can SELECT own job_views'
+);
+
+SELECT is(
+  (SELECT b_can_see_a FROM _rls_job_views_ctx),
+  0,
+  'User B CANNOT see User A job_views'
+);
+
+SELECT is(
+  (SELECT b_inserted FROM _rls_job_views_ctx),
+  0,
+  'User B CANNOT INSERT a view with another user_id'
+);
+
+SELECT is(
+  (SELECT rows_after_del FROM _rls_job_views_ctx),
+  1,
+  'User B CANNOT DELETE User A job_views (verified from service_role)'
+);
+
+-- Test 5: RLS table metadata — no UPDATE policy should exist for job_views
+SELECT is(
+  (
+    SELECT COUNT(*)::INTEGER
+    FROM pg_policies
+    WHERE tablename = 'job_views'
+      AND cmd IN ('UPDATE', 'DELETE')
+  ),
+  0,
+  'No UPDATE or DELETE RLS policies exist on job_views (immutable audit records)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
﻿## Contexte

Issue #11 — FM08 (sauvegarde d'offres) + FM09 (tracking postulation).

## Changements

### Server Actions (`app/(protected)/saved/actions.ts`)
- `saveJob(jobId)` — upsert `saved_jobs` avec `status='saved'` (idempotent via ON CONFLICT DO NOTHING)
- `unsaveJob(jobId)` — DELETE `saved_jobs`
- `updateSavedJobStatus(jobId, status)` — UPDATE statut parmi `saved | applied | rejected | interviewing | offered`
- Validation Zod (UUID + enum) + `getUser()` en entrée de chaque action

### Client Components
- `BookmarkButton` — `useOptimistic` pour feedback immédiat, rollback auto sur erreur, `toastError`
- `ApplyButton` — lien `target="_blank"` + `navigator.sendBeacon` fire-and-forget vers `track-apply`
- `SavedJobList` — rendu liste `/saved` avec select statut inline

### Route handler
- `POST /api/jobs/[id]/track-apply` — insère `job_views { action: 'click_apply' }`, 204 No Content
- Auth 401, UUID invalide 400, DB error 500

### Feed
- `feed/page.tsx` : fetch `savedJobIds` en parallèle du feed (Promise.all)
- `job-feed-list.tsx` : `BookmarkButton` + `ApplyButton` intégrés dans chaque item de la liste

### Page `/saved`
- Server Component : `saved_jobs JOIN jobs` triés par `saved_at DESC`
- Guard onboarding (redirect si `onboarding_completed_at IS NULL`)

### pgTAP
- `supabase/tests/rls_job_views.sql` — 5 assertions : isolation SELECT, INSERT cross-user bloqué, DELETE cross-user bloqué, aucune policy UPDATE/DELETE

## Tests

- 33 nouveaux tests unitaires (actions + composants + route handler)
- 955/955 total (0 failures)
- 0 erreurs TypeScript, 0 warnings ESLint

## Critères d'acceptation

- [x] Bookmark fonctionnel (save/unsave avec feedback optimiste)
- [x] Page /saved accessible avec liste, statut et bouton Postuler
- [x] Chaque clic Postuler tracké dans `job_views`
- [x] RLS : utilisateur ne voit que ses propres offres sauvegardées
